### PR TITLE
Basic Articles module

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "i18next": "^25.5.2",
+        "ky": "^1.14.2",
         "lucide-react": "^0.542.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -98,7 +99,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1003,7 +1003,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.1.tgz",
       "integrity": "sha512-x0cR55ILVqFpUioSMf6ebpRCMXMcheGN743P05W2RB5uCNpJUqWIqW66Lap8PfL/lngvjTbZj0BNSUweIr/fHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.0.1"
       },
@@ -2310,7 +2309,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2735,7 +2733,6 @@
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2746,7 +2743,6 @@
       "integrity": "sha512-BnsPLV43ddr05N71gaGzyZ5hzkCmGwhMvYc8zmvI8Ci1bRkkDSzDDVfAXfN2tk748OwI7ediiPX6PfT9p0QGVg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2757,7 +2753,6 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2808,7 +2803,6 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -3060,7 +3054,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3198,7 +3191,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3655,7 +3647,6 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4212,7 +4203,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -4327,9 +4317,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4401,6 +4391,18 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.2.tgz",
+      "integrity": "sha512-q3RBbsO5A5zrPhB6CaCS8ZUv+NWCXv6JJT4Em0i264G9W0fdPB8YRfnnEi7Dm7X7omAkBIPojzYJ2D1oHTHqug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/levn": {
@@ -4803,9 +4805,9 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4813,22 +4815,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -5205,7 +5191,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5215,7 +5200,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5228,7 +5212,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
       "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5324,9 +5307,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
-      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5394,7 +5377,6 @@
       "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -5596,17 +5578,16 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
+      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {
@@ -5667,7 +5648,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5775,7 +5755,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5899,12 +5878,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6030,7 +6008,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^25.5.2",
+    "ky": "^1.14.2",
     "lucide-react": "^0.542.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,7 @@ import { Container } from '@/components/container/Container';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/providers/AuthProvider';
-import { RegistrationPage, StartPage } from '@/pages';
+import { ArticleDetailedPage, RegistrationPage, StartPage } from '@/pages';
 import { ErrorBoundary } from './pages/NotFoundErrorBoundary';
 import { GoogleAuthRedirectPage } from './pages/auth/GoogleAuthRedirectPage';
 
@@ -27,7 +27,11 @@ function App() {
         {
           path: '/google-auth',
           Component: GoogleAuthRedirectPage,
-        }
+        },
+        {
+          path: '/articles/:id',
+          Component: ArticleDetailedPage,
+        },
       ],
     },
   ]);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,9 +2,14 @@ import { Container } from '@/components/container/Container';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/providers/AuthProvider';
-import { ArticleDetailedPage, RegistrationPage, StartPage } from '@/pages';
+import {
+  ArticleDetailedPage,
+  ArticlesIndexPage,
+  RegistrationPage,
+  GoogleAuthRedirectPage,
+  StartPage,
+} from '@/pages';
 import { ErrorBoundary } from './pages/NotFoundErrorBoundary';
-import { GoogleAuthRedirectPage } from './pages/auth/GoogleAuthRedirectPage';
 
 const queryClient = new QueryClient({
   defaultOptions: { mutations: { retry: false } },
@@ -29,8 +34,14 @@ function App() {
           Component: GoogleAuthRedirectPage,
         },
         {
-          path: '/articles/:id',
-          Component: ArticleDetailedPage,
+          path: '/articles',
+          children: [
+            { index: true, Component: ArticlesIndexPage },
+            {
+              path: ':id',
+              Component: ArticleDetailedPage,
+            },
+          ],
         },
       ],
     },

--- a/client/src/api/ky.ts
+++ b/client/src/api/ky.ts
@@ -1,0 +1,103 @@
+import ky, { HTTPError } from 'ky';
+import AuthService from '@/api/services/auth.service';
+import { ACCESS_TOKEN } from '^/constants/auth.constants';
+
+let isRefreshing = false;
+let refreshSubscribers: Array<(token: string | null) => void> = [];
+
+const subscribeTokenRefresh = (cb: (token: string | null) => void) => {
+  refreshSubscribers.push(cb);
+};
+
+const onRefreshed = (token: string | null) => {
+  refreshSubscribers.forEach((cb) => cb(token));
+  refreshSubscribers = [];
+};
+
+const api = ky.create({
+  prefixUrl: import.meta.env.VITE_BACKEND_URI,
+  credentials: 'include',
+  hooks: {
+    beforeRequest: [
+      (request) => {
+        const accessToken = localStorage.getItem(ACCESS_TOKEN);
+        if (accessToken) {
+          request.headers.set('Authorization', `Bearer ${accessToken}`);
+        }
+      },
+    ],
+    afterResponse: [
+      async (request, options, response) => {
+        if (response.status !== 401) return;
+
+        // Don't refresh on refresh endpoint itself
+        if (
+          request.url.includes('/auth/refresh') ||
+          request.url.includes('refresh')
+        ) {
+          throw new HTTPError(response, request, options);
+        }
+
+        if (isRefreshing) {
+          // Wait for refresh to finish, then retry
+          return new Promise<Response>((resolve, reject) => {
+            subscribeTokenRefresh(async (token) => {
+              if (!token) {
+                reject(new HTTPError(response, request, options));
+                return;
+              }
+              try {
+                const retryResponse = await ky(request, {
+                  ...options,
+                  headers: {
+                    ...options.headers,
+                    Authorization: `Bearer ${token}`,
+                  },
+                });
+                resolve(retryResponse);
+              } catch (e) {
+                reject(e);
+              }
+            });
+          });
+        }
+
+        isRefreshing = true;
+        try {
+          const refreshResult = await AuthService.refresh();
+          const accessToken =
+            refreshResult?.response?.data?.tokens?.accessToken ?? null;
+
+          if (!accessToken) {
+            throw new Error('No access token returned from refresh');
+          }
+
+          localStorage.setItem(ACCESS_TOKEN, accessToken);
+          onRefreshed(accessToken);
+
+          // Retry original request with new token
+          return ky(request, {
+            ...options,
+            headers: {
+              ...options.headers,
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+        } catch (e) {
+          onRefreshed(null);
+          localStorage.removeItem(ACCESS_TOKEN);
+          try {
+            await AuthService.logout();
+          } catch {
+            /* ignore */
+          }
+          throw e;
+        } finally {
+          isRefreshing = false;
+        }
+      },
+    ],
+  },
+});
+
+export { api as kyApi };

--- a/client/src/api/scopes/articles.ts
+++ b/client/src/api/scopes/articles.ts
@@ -1,5 +1,9 @@
 import type { TResponse } from '^/types/response/response.type';
-import type { ArticleDetailed, ArticleShort } from '^/types/articles';
+import type {
+  ArticleCreate,
+  ArticleDetailed,
+  ArticleShort,
+} from '^/types/articles';
 import { kyApi } from '../ky';
 import { backendPath } from '@/lib/routing/backend';
 
@@ -19,4 +23,18 @@ export async function getArticleById(
   );
 
   return await article.json();
+}
+
+export async function createArticle(article: ArticleCreate): Promise<void> {
+  await kyApi.post(backendPath('ArticleBase'), {
+    json: article,
+  });
+}
+
+export async function softDeleteArticle(id: string): Promise<void> {
+  await kyApi.delete(
+    backendPath('ArticleSoftDelete', {
+      id,
+    }),
+  );
 }

--- a/client/src/api/scopes/articles.ts
+++ b/client/src/api/scopes/articles.ts
@@ -1,9 +1,22 @@
 import type { TResponse } from '^/types/response/response.type';
-import type { ArticleShort } from '^/types/articles';
+import type { ArticleDetailed, ArticleShort } from '^/types/articles';
 import { kyApi } from '../ky';
+import { backendPath } from '@/lib/routing/backend';
 
 export async function getArticles(): Promise<TResponse<ArticleShort[]>> {
   const articles = await kyApi.get<TResponse<ArticleShort[]>>('articles');
 
   return await articles.json();
+}
+
+export async function getArticleById(
+  id: string,
+): Promise<TResponse<ArticleDetailed>> {
+  const article = await kyApi.get<TResponse<ArticleShort[]>>(
+    backendPath('ArticleDetailed', {
+      id,
+    }),
+  );
+
+  return await article.json();
 }

--- a/client/src/api/scopes/articles.ts
+++ b/client/src/api/scopes/articles.ts
@@ -3,6 +3,7 @@ import type {
   ArticleCreate,
   ArticleDetailed,
   ArticleShort,
+  ArticleEdit,
 } from '^/types/articles';
 import { kyApi } from '../ky';
 import { backendPath } from '@/lib/routing/backend';
@@ -29,6 +30,20 @@ export async function createArticle(article: ArticleCreate): Promise<void> {
   await kyApi.post(backendPath('ArticleBase'), {
     json: article,
   });
+}
+
+export async function updateArticle(
+  id: string,
+  partialArticle: ArticleEdit,
+): Promise<void> {
+  await kyApi.patch(
+    backendPath('ArticleUpdate', {
+      id,
+    }),
+    {
+      json: partialArticle,
+    },
+  );
 }
 
 export async function softDeleteArticle(id: string): Promise<void> {

--- a/client/src/api/scopes/articles.ts
+++ b/client/src/api/scopes/articles.ts
@@ -1,0 +1,9 @@
+import type { TResponse } from '^/types/response/response.type';
+import type { ArticleShort } from '^/types/articles';
+import { kyApi } from '../ky';
+
+export async function getArticles(): Promise<TResponse<ArticleShort[]>> {
+  const articles = await kyApi.get<TResponse<ArticleShort[]>>('articles');
+
+  return await articles.json();
+}

--- a/client/src/components/container/Container.tsx
+++ b/client/src/components/container/Container.tsx
@@ -6,10 +6,10 @@ import { Toaster } from 'sonner';
 export const Container = () => (
   <main className="flex min-h-screen flex-col">
     <Header />
-    <div className="mx-8 my-4 flex min-h-0 flex-1">
+    <div className="mx-8 my-4 flex min-h-0 flex-1 md:mx-10">
       <Outlet />
     </div>
     <Footer />
-    <Toaster richColors toastOptions={{ className: 'font-inter',  }} />
+    <Toaster richColors toastOptions={{ className: 'font-inter' }} />
   </main>
 );

--- a/client/src/components/container/header/Header.tsx
+++ b/client/src/components/container/header/Header.tsx
@@ -12,9 +12,9 @@ export const Header = () => {
     <header className="bg-light-active sticky top-0 flex h-16 w-full items-center justify-between px-8">
       <div className="flex flex-row items-center gap-6">
         <HeaderLogo />
-        <div className="md:flex gap-6 hidden">
-          <HeaderLink to="/" title={t('header.sections.news')} />
-          <HeaderLink to="/events" title={t('header.sections.events')}  />
+        <div className="hidden gap-6 md:flex">
+          <HeaderLink to="/articles" title={t('header.sections.news')} />
+          <HeaderLink to="/events" title={t('header.sections.events')} />
         </div>
       </div>
       <DropdownDialogProvider initialValue={undefined}>

--- a/client/src/components/features/articles/Article.tsx
+++ b/client/src/components/features/articles/Article.tsx
@@ -1,0 +1,31 @@
+import type { ArticleShort } from '^/types/articles';
+import { Typography } from '@/components/common/typography/Typography';
+import { cn } from '@/lib/utils';
+
+type Sizes = 'sm' | 'md' | 'lg'
+
+type ArticleProps = {
+  article: ArticleShort;
+  size?: Sizes;
+};
+
+export const Article = ({ article, size = 'sm' }: ArticleProps) => {
+  return (
+    <div className="flex flex-col gap-y-2">
+      <img
+        className={cn('rounded-md')}
+        alt={article.title}
+        src={article.imageUrl}
+        title={article.title}
+      />
+      <Typography variant="2xl" weight="semibold">
+        {article.title}
+      </Typography>
+      {size !== 'sm' && (
+        <Typography variant="sm" className="text-black/85">
+          {article.previewText ?? 'More to follow...'}
+        </Typography>
+      )}
+    </div>
+  );
+};

--- a/client/src/components/features/articles/Article.tsx
+++ b/client/src/components/features/articles/Article.tsx
@@ -1,8 +1,10 @@
 import type { ArticleShort } from '^/types/articles';
 import { Typography } from '@/components/common/typography/Typography';
 import { cn } from '@/lib/utils';
+import { Link } from 'react-router';
+import { path } from '@/lib/routing/client';
 
-type Sizes = 'sm' | 'md' | 'lg'
+type Sizes = 'sm' | 'md' | 'lg';
 
 type ArticleProps = {
   article: ArticleShort;
@@ -11,21 +13,24 @@ type ArticleProps = {
 
 export const Article = ({ article, size = 'sm' }: ArticleProps) => {
   return (
-    <div className="flex flex-col gap-y-2">
+    <Link
+      to={path('ArticleDetailed', { id: article.id })}
+      className="flex flex-col gap-y-2"
+    >
       <img
         className={cn('rounded-md')}
         alt={article.title}
         src={article.imageUrl}
         title={article.title}
       />
-      <Typography variant="2xl" weight="semibold">
+      <Typography variant="3xl" weight="semibold">
         {article.title}
       </Typography>
       {size !== 'sm' && (
-        <Typography variant="sm" className="text-black/85">
+        <Typography variant="lg" className="text-black/85">
           {article.previewText ?? 'More to follow...'}
         </Typography>
       )}
-    </div>
+    </Link>
   );
 };

--- a/client/src/components/features/articles/ArticleCreateForm.tsx
+++ b/client/src/components/features/articles/ArticleCreateForm.tsx
@@ -1,0 +1,129 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { createArticleSchema } from '^/schemas/articles/create-article.schema';
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogTrigger,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useCreateArticle } from '@/hooks/articles/useCreateArticle';
+import type { ArticleCreate } from '^/types/articles';
+import { FormField } from '@/components/common/form/FormField';
+import { Spinner } from '@/components/common/spinner/Spinner';
+import { DialogClose } from '@/components/ui/dialog';
+import { TranslationNamespaceProvider } from '@/contexts/TranslationNamespaceContext';
+import { useCloseDialog } from '@/hooks/ui/useCloseDialog';
+
+export const ArticleCreateForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors: formErrors },
+  } = useForm({
+    resolver: yupResolver(createArticleSchema),
+    mode: 'onChange',
+  });
+
+  const { mutateAsync, isPending } = useCreateArticle();
+  const { closeHidden, closeRef } = useCloseDialog();
+
+  const onSubmit: SubmitHandler<ArticleCreate> = async (data) => {
+    try {
+      await mutateAsync(data);
+
+      closeRef.current?.click();
+    } catch (error) {
+      console.error('Error creating article:', error);
+    }
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Create Article</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Article creation</DialogTitle>
+          <DialogDescription>Create a new article</DialogDescription>
+        </DialogHeader>
+        <TranslationNamespaceProvider namespace={'auth'}>
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col space-y-4"
+          >
+            <FormField
+              id="title"
+              label="Title"
+              errorMessage={formErrors.title?.message}
+            >
+              <Input
+                id="title"
+                placeholder="Article title"
+                {...register('title')}
+              />
+            </FormField>
+
+            <FormField
+              id="previewText"
+              label="Preview Text"
+              errorMessage={formErrors.previewText?.message}
+            >
+              <Input
+                id="previewText"
+                placeholder="Preview text (optional)"
+                {...register('previewText')}
+              />
+            </FormField>
+
+            <FormField
+              id="text"
+              label="Text"
+              errorMessage={formErrors.text?.message}
+            >
+              <textarea
+                id="text"
+                placeholder="Article text (optional)"
+                className="w-full rounded-lg border p-2"
+                {...register('text')}
+              />
+            </FormField>
+
+            <FormField
+              id="imageUrl"
+              label="Image URL"
+              errorMessage={formErrors.imageUrl?.message}
+            >
+              <Input
+                id="imageUrl"
+                placeholder="https://example.com/image.jpg"
+                {...register('imageUrl')}
+              />
+            </FormField>
+
+            <div className="flex gap-2">
+              <Button
+                type="submit"
+                disabled={!isValid || isPending}
+                className="flex-1"
+              >
+                {isPending ? <Spinner /> : 'Create'}
+              </Button>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </DialogClose>
+            </div>
+          </form>
+        </TranslationNamespaceProvider>
+        {closeHidden}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/components/features/articles/ArticleUpdateForm.tsx
+++ b/client/src/components/features/articles/ArticleUpdateForm.tsx
@@ -1,0 +1,172 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { editArticleSchema } from '^/schemas/articles/edit-article.schema';
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogTrigger,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useEditArticle } from '@/hooks/articles/useUpdateArticle';
+import { useGetArticleById } from '@/hooks/articles/useGetArticleById';
+import type { ArticleEdit } from '^/types/articles';
+import { FormField } from '@/components/common/form/FormField';
+import { Spinner } from '@/components/common/spinner/Spinner';
+import { DialogClose } from '@/components/ui/dialog';
+import { TranslationNamespaceProvider } from '@/contexts/TranslationNamespaceContext';
+import { useCloseDialog } from '@/hooks/ui/useCloseDialog';
+import { useEffect, useRef } from 'react';
+import { useResponse } from '@/hooks/data-handling/useResponse';
+
+type ArticleUpdateFormProps = {
+  articleId: string;
+};
+
+export const ArticleUpdateForm = ({ articleId }: ArticleUpdateFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, isDirty, errors: formErrors },
+    reset,
+  } = useForm({
+    resolver: yupResolver(editArticleSchema),
+    mode: 'onChange',
+  });
+
+  const { data: articleData, isLoading: isLoadingArticle } =
+    useGetArticleById(articleId);
+  const { mutateAsync, isPending } = useEditArticle(articleId);
+  const { closeHidden, closeRef } = useCloseDialog();
+  const originalArticleRef = useRef<ArticleEdit>({});
+
+  const { data: article } = useResponse(articleData);
+
+  useEffect(() => {
+    if (article) {
+      const initialValues = {
+        title: article.title,
+        previewText: article.previewText || '',
+        text: article.text || '',
+        imageUrl: article.imageUrl,
+      };
+      originalArticleRef.current = initialValues;
+      reset(initialValues);
+    }
+  }, [article, reset]);
+
+  const onSubmit: SubmitHandler<ArticleEdit> = async (data) => {
+    try {
+      const changedFields: ArticleEdit = {};
+      let hasChanges = false;
+
+      (Object.keys(data) as Array<keyof ArticleEdit>).forEach((key) => {
+        if (data[key] !== originalArticleRef.current[key]) {
+          changedFields[key] = data[key];
+          hasChanges = true;
+        }
+      });
+
+      if (!hasChanges) {
+        return;
+      }
+      await mutateAsync(changedFields);
+
+      closeRef.current?.click();
+    } catch (error) {
+      console.error('Error updating article:', error);
+    }
+  };
+
+  if (isLoadingArticle) {
+    return <Spinner />;
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Edit Article</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Article update</DialogTitle>
+          <DialogDescription>Update the article</DialogDescription>
+        </DialogHeader>
+        <TranslationNamespaceProvider namespace={'auth'}>
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col space-y-4"
+          >
+            <FormField
+              id="title"
+              label="Title"
+              errorMessage={formErrors.title?.message}
+            >
+              <Input
+                id="title"
+                placeholder="Article title"
+                {...register('title')}
+              />
+            </FormField>
+
+            <FormField
+              id="previewText"
+              label="Preview Text"
+              errorMessage={formErrors.previewText?.message}
+            >
+              <Input
+                id="previewText"
+                placeholder="Preview text (optional)"
+                {...register('previewText')}
+              />
+            </FormField>
+
+            <FormField
+              id="text"
+              label="Text"
+              errorMessage={formErrors.text?.message}
+            >
+              <textarea
+                id="text"
+                placeholder="Article text (optional)"
+                className="w-full rounded-lg border p-2"
+                {...register('text')}
+              />
+            </FormField>
+
+            <FormField
+              id="imageUrl"
+              label="Image URL"
+              errorMessage={formErrors.imageUrl?.message}
+            >
+              <Input
+                id="imageUrl"
+                placeholder="https://example.com/image.jpg"
+                {...register('imageUrl')}
+              />
+            </FormField>
+
+            <div className="flex gap-2">
+              <Button
+                type="submit"
+                disabled={!isValid || !isDirty || isPending}
+                className="flex-1"
+              >
+                {isPending ? <Spinner /> : 'Update'}
+              </Button>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </DialogClose>
+            </div>
+          </form>
+        </TranslationNamespaceProvider>
+        {closeHidden}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/hooks/articles/useCreateArticle.ts
+++ b/client/src/hooks/articles/useCreateArticle.ts
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query';
+import { createArticle } from '@/api/scopes/articles';
+import type { ArticleCreate } from '^/types/articles';
+import { toast } from 'sonner';
+
+export const useCreateArticle = () =>
+  useMutation({
+    mutationKey: ['article-create'],
+    mutationFn: (article: ArticleCreate) => createArticle(article),
+    onSuccess: () => {
+      toast.success('Article successfully created');
+    },
+  });

--- a/client/src/hooks/articles/useDeleteArticle.ts
+++ b/client/src/hooks/articles/useDeleteArticle.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import { softDeleteArticle } from '@/api/scopes/articles';
+import { useNavigate } from 'react-router';
+import { toast } from 'sonner';
+
+export const useDeleteArticle = (id: string) => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationKey: ['article-soft-delete', id],
+    mutationFn: () => softDeleteArticle(id),
+    onSuccess: () => {
+      toast.info('Article is deleted deleted');
+
+      navigate('/');
+    },
+    onError: (error) => {
+      toast.error('Unable to delete the article', {
+        description: error.message,
+      });
+    },
+  });
+};

--- a/client/src/hooks/articles/useGetArticleById.ts
+++ b/client/src/hooks/articles/useGetArticleById.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
+import { getArticleById } from '@/api/scopes/articles';
+
+export const useGetArticleById = (id: string) =>
+  useQuery({
+    queryKey: ['article-detailed', id],
+    queryFn: () => getArticleById(id),
+  });

--- a/client/src/hooks/articles/useGetArticles.ts
+++ b/client/src/hooks/articles/useGetArticles.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
+import { getArticles } from '@/api/scopes/articles';
+
+export const useGetArticles = () =>
+  useQuery({
+    queryKey: ['articles'],
+    queryFn: getArticles,
+  });

--- a/client/src/hooks/articles/useUpdateArticle.ts
+++ b/client/src/hooks/articles/useUpdateArticle.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateArticle } from '@/api/scopes/articles';
+import type { ArticleEdit } from '^/types/articles';
+import { toast } from 'sonner';
+
+export const useEditArticle = (id: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['article-edit', id],
+    mutationFn: (article: ArticleEdit) => updateArticle(id, article),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['article-detailed', id] });
+      toast.success('Article successfully edited');
+    },
+  });
+};

--- a/client/src/hooks/data-handling/useResponse.ts
+++ b/client/src/hooks/data-handling/useResponse.ts
@@ -1,0 +1,12 @@
+import type { TResponse } from '^/types/response/response.type';
+
+export const useResponse = <T = unknown>(res?: TResponse<T>) => {
+  const data = null;
+  const error = null;
+  
+  if (res?.response.data) return { data: res.response.data, error };
+
+  if (res?.response.error) return { data, error: res.response.error };
+
+  return { data, error };
+};

--- a/client/src/lib/routing/backend.ts
+++ b/client/src/lib/routing/backend.ts
@@ -8,5 +8,24 @@ export const BackendRoutes = {
 
   // User routes
   Users: '/users',
+
+  // Article routes
+  ArticleDetailed: 'articles/:id',
 } as const;
 
+type RoutesKeys = keyof typeof BackendRoutes;
+type Params = Record<string, string | number>;
+
+export function backendPath<K extends RoutesKeys>(
+  page: K,
+  params?: Params,
+): string {
+  let route = BackendRoutes[page] as string;
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      route = route.replace(`:${key}`, encodeURIComponent(String(value)));
+    });
+  }
+  return route;
+}

--- a/client/src/lib/routing/backend.ts
+++ b/client/src/lib/routing/backend.ts
@@ -10,7 +10,9 @@ export const BackendRoutes = {
   Users: '/users',
 
   // Article routes
+  ArticleBase: 'articles',
   ArticleDetailed: 'articles/:id',
+  ArticleSoftDelete: 'articles/soft/:id',
 } as const;
 
 type RoutesKeys = keyof typeof BackendRoutes;

--- a/client/src/lib/routing/backend.ts
+++ b/client/src/lib/routing/backend.ts
@@ -12,6 +12,7 @@ export const BackendRoutes = {
   // Article routes
   ArticleBase: 'articles',
   ArticleDetailed: 'articles/:id',
+  ArticleUpdate: 'articles/update/:id',
   ArticleSoftDelete: 'articles/soft/:id',
 } as const;
 

--- a/client/src/lib/routing/client.ts
+++ b/client/src/lib/routing/client.ts
@@ -1,0 +1,17 @@
+export const Pages = {
+  ArticleDetailed: '/articles/:id',
+} as const;
+
+type PagesKeys = keyof typeof Pages;
+type Params = Record<string, string | number>;
+
+export function path<K extends PagesKeys>(page: K, params?: Params): string {
+  let route = Pages[page] as string;
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      route = route.replace(`:${key}`, encodeURIComponent(String(value)));
+    });
+  }
+  return route;
+}

--- a/client/src/pages/StartPage.tsx
+++ b/client/src/pages/StartPage.tsx
@@ -15,7 +15,7 @@ export const StartPage = () => {
       <div className='max-w-1/2'>
         <Article article={newestArticle} size="lg" />
       </div>
-      <div className="grid w-2/5 grid-cols-2 gap-x-3">
+      <div className="grid w-2/5 grid-cols-2 gap-x-3 gap-y-2">
         {articles.slice(1).map((it) => (
           <Article key={it.id} article={it} size='md' />
         ))}

--- a/client/src/pages/StartPage.tsx
+++ b/client/src/pages/StartPage.tsx
@@ -1,36 +1,24 @@
-import { useUserStore } from '@/stores/user.store';
-import { useShallow } from 'zustand/react/shallow';
-import { Button } from '@/components/ui/button';
-import { toast } from 'sonner';
-import { Typography } from '@/components/common/typography/Typography';
-import { SonnerLoader } from '../components/common/spinner/Spinner';
+import { useGetArticles } from '@/hooks/articles/useGetArticles';
+import { useResponse } from '@/hooks/data-handling/useResponse';
+import { Article } from '@/components/features/articles/Article';
 
 export const StartPage = () => {
-  const { user, loadingFlag } = useUserStore(
-    useShallow((state) => ({
-      user: state.user,
-      loadingFlag: state.loadingInfo,
-    })),
-  );
+  const { isFetched, data: articlesResponse } = useGetArticles();
+  const { data: articles } = useResponse(articlesResponse);
 
-  const cb = () => {
-    toast.loading('idkbruv', {
-      description: 'wow',
-    });
-  };
+  if (!isFetched || !articles) return null;
 
-  const { isLoading } = loadingFlag;
+  const newestArticle = articles[0];
 
   return (
-    <div className="flex flex-col">
-      <Button className="size-fit" onClick={cb}>
-        Click
-      </Button>
-      {!user && isLoading && <Typography>Loading</Typography>}
-      {user && <Typography>{JSON.stringify(user, null, 2)}</Typography>}
-      <Typography>hello</Typography>
-      <div className='max-h-10'>
-        <SonnerLoader  visible />
+    <div className="flex justify-between">
+      <div className='max-w-1/2'>
+        <Article article={newestArticle} size="lg" />
+      </div>
+      <div className="grid w-2/5 grid-cols-2 gap-x-3">
+        {articles.slice(1).map((it) => (
+          <Article key={it.id} article={it} size='md' />
+        ))}
       </div>
     </div>
   );

--- a/client/src/pages/articles/ArticleDetailedPage.tsx
+++ b/client/src/pages/articles/ArticleDetailedPage.tsx
@@ -1,0 +1,25 @@
+import { useParams } from 'react-router';
+import { useGetArticleById } from '@/hooks/articles/useGetArticleById';
+import { useResponse } from '@/hooks/data-handling/useResponse';
+import { Article } from '@/components/features/articles/Article';
+import { Typography } from '@/components/common/typography/Typography';
+
+export const ArticleDetailedPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: articleRes, isFetched } = useGetArticleById(id!);
+
+  const { data: article } = useResponse(articleRes);
+
+  if (!isFetched || !article) return null;
+
+  return (
+    <div className="flex flex-col">
+      <div className="w-1/2">
+        <Article article={article} size="lg" />
+      </div>
+      <Typography className="mt-2 w-1/2" variant='md'>
+        {article.text}
+      </Typography>
+    </div>
+  );
+};

--- a/client/src/pages/articles/ArticleDetailedPage.tsx
+++ b/client/src/pages/articles/ArticleDetailedPage.tsx
@@ -3,10 +3,15 @@ import { useGetArticleById } from '@/hooks/articles/useGetArticleById';
 import { useResponse } from '@/hooks/data-handling/useResponse';
 import { Article } from '@/components/features/articles/Article';
 import { Typography } from '@/components/common/typography/Typography';
+import { useDeleteArticle } from '@/hooks/articles/useDeleteArticle';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/common/spinner/Spinner';
 
 export const ArticleDetailedPage = () => {
   const { id } = useParams<{ id: string }>();
   const { data: articleRes, isFetched } = useGetArticleById(id!);
+  const { mutate: deleteArticle, isPending: deletionPending } =
+    useDeleteArticle(id!);
 
   const { data: article } = useResponse(articleRes);
 
@@ -17,9 +22,12 @@ export const ArticleDetailedPage = () => {
       <div className="w-1/2">
         <Article article={article} size="lg" />
       </div>
-      <Typography className="mt-2 w-1/2" variant='md'>
+      <Typography className="mt-2 w-1/2" variant="md">
         {article.text}
       </Typography>
+      <Button className='w-28' onClick={() => deleteArticle()}>
+        {deletionPending ? <Spinner /> : 'Delete article'}
+      </Button>
     </div>
   );
 };

--- a/client/src/pages/articles/ArticleDetailedPage.tsx
+++ b/client/src/pages/articles/ArticleDetailedPage.tsx
@@ -6,6 +6,7 @@ import { Typography } from '@/components/common/typography/Typography';
 import { useDeleteArticle } from '@/hooks/articles/useDeleteArticle';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/common/spinner/Spinner';
+import { ArticleUpdateForm } from '../../components/features/articles/ArticleUpdateForm';
 
 export const ArticleDetailedPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -15,7 +16,7 @@ export const ArticleDetailedPage = () => {
 
   const { data: article } = useResponse(articleRes);
 
-  if (!isFetched || !article) return null;
+  if (!isFetched || !article || !id) return null;
 
   return (
     <div className="flex flex-col">
@@ -25,9 +26,12 @@ export const ArticleDetailedPage = () => {
       <Typography className="mt-2 w-1/2" variant="md">
         {article.text}
       </Typography>
-      <Button className='w-28' onClick={() => deleteArticle()}>
-        {deletionPending ? <Spinner /> : 'Delete article'}
-      </Button>
+      <div className="flex flex-row space-x-2">
+        <ArticleUpdateForm articleId={id} />
+        <Button className="w-28" onClick={() => deleteArticle()}>
+          {deletionPending ? <Spinner /> : 'Delete article'}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/client/src/pages/articles/ArticlesIndexPage.tsx
+++ b/client/src/pages/articles/ArticlesIndexPage.tsx
@@ -1,0 +1,5 @@
+import { ArticleCreateForm } from '@/components/features/articles/ArticleCreateForm';
+
+export const ArticlesIndexPage = () => {
+  return <ArticleCreateForm />;
+};

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -1,2 +1,7 @@
 export { StartPage } from './StartPage';
+
+// Auth pages
 export { RegistrationPage } from './auth/RegistrationPage';
+
+// Article pages
+export { ArticleDetailedPage } from './articles/ArticleDetailedPage';

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -2,6 +2,8 @@ export { StartPage } from './StartPage';
 
 // Auth pages
 export { RegistrationPage } from './auth/RegistrationPage';
+export { GoogleAuthRedirectPage } from './auth/GoogleAuthRedirectPage';
 
 // Article pages
+export { ArticlesIndexPage } from './articles/ArticlesIndexPage';
 export { ArticleDetailedPage } from './articles/ArticleDetailedPage';

--- a/client/utils/schemas/articles/create-article.schema.ts
+++ b/client/utils/schemas/articles/create-article.schema.ts
@@ -1,0 +1,21 @@
+import * as yup from 'yup';
+
+export const createArticleSchema = yup.object({
+  title: yup
+    .string()
+    .required('Title is required')
+    .min(25, 'Title must be at least 25 characters')
+    .max(125, 'Title must not exceed 125 characters'),
+  previewText: yup
+    .string()
+    .max(200, 'Preview text must not exceed 200 characters')
+    .optional(),
+  text: yup
+    .string()
+    .max(2000, 'Text must not exceed 2000 characters')
+    .optional(),
+  imageUrl: yup
+    .string()
+    .required('Image URL is required')
+    .url('Image URL must be a valid URL'),
+});

--- a/client/utils/schemas/articles/edit-article.schema.ts
+++ b/client/utils/schemas/articles/edit-article.schema.ts
@@ -1,0 +1,17 @@
+import * as yup from 'yup';
+
+export const editArticleSchema = yup.object({
+  title: yup
+    .string()
+    .min(25, 'Title must be at least 25 characters')
+    .max(125, 'Title must not exceed 125 characters'),
+  previewText: yup
+    .string()
+    .max(200, 'Preview text must not exceed 200 characters'),
+  text: yup
+    .string()
+    .max(2000, 'Text must not exceed 2000 characters'),
+  imageUrl: yup
+    .string()
+    .url('Image URL must be a valid URL'),
+});

--- a/client/utils/types/articles/index.ts
+++ b/client/utils/types/articles/index.ts
@@ -17,3 +17,5 @@ export type ArticleCreate = {
   text?: string;
   imageUrl: string;
 };
+
+export type ArticleEdit = Partial<ArticleCreate>;

--- a/client/utils/types/articles/index.ts
+++ b/client/utils/types/articles/index.ts
@@ -10,3 +10,10 @@ export type ArticleShort = {
 export type ArticleDetailed = ArticleShort & {
   text: string | null;
 };
+
+export type ArticleCreate = {
+  title: string;
+  previewText?: string;
+  text?: string;
+  imageUrl: string;
+};

--- a/client/utils/types/articles/index.ts
+++ b/client/utils/types/articles/index.ts
@@ -6,3 +6,7 @@ export type ArticleShort = {
   createdAt: Date;
   updatedAt: Date | null;
 };
+
+export type ArticleDetailed = ArticleShort & {
+  text: string | null;
+};

--- a/client/utils/types/articles/index.ts
+++ b/client/utils/types/articles/index.ts
@@ -1,0 +1,8 @@
+export type ArticleShort = {
+  id: string;
+  title: string;
+  previewText: string | null;
+  imageUrl: string;
+  createdAt: Date;
+  updatedAt: Date | null;
+};

--- a/server/src/common/constants/database.constants.ts
+++ b/server/src/common/constants/database.constants.ts
@@ -1,3 +1,7 @@
+import { IsNull, Not } from 'typeorm';
+
 export const CREATED_AT_COLUMN_NAME = 'created_at';
 
 export const UPDATED_AT_COLUMN_NAME = 'updated_at';
+
+export const NotNull = Not(IsNull());

--- a/server/src/features/articles/artice.repository.ts
+++ b/server/src/features/articles/artice.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Article } from './article.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class ArticleRepository {
+  constructor(@InjectRepository(Article) private repo: Repository<Article>) {}
+
+  async findArticles(): Promise<Article[]> {
+    return await this.repo.find({
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+  }
+  // TODO: add "not available" if soft deleted
+  async findArticleById(id: string): Promise<Article> {
+    const entity = await this.repo.findOne({
+      where: { id },
+    });
+    if (!entity) throw new NotFoundException('This article does not exist');
+
+    return entity;
+  }
+}

--- a/server/src/features/articles/artice.repository.ts
+++ b/server/src/features/articles/artice.repository.ts
@@ -9,6 +9,14 @@ export class ArticleRepository {
 
   async findArticles(): Promise<Article[]> {
     return await this.repo.find({
+      select: {
+        id: true,
+        title: true,
+        imageUrl: true,
+        previewText: true,
+        createdAt: true,
+        updatedAt: true,
+      },
       order: {
         createdAt: 'DESC',
       },

--- a/server/src/features/articles/article.constants.ts
+++ b/server/src/features/articles/article.constants.ts
@@ -1,0 +1,8 @@
+export const ARTICLES_SELECT_OBJ = {
+  id: true,
+  title: true,
+  imageUrl: true,
+  previewText: true,
+  createdAt: true,
+  updatedAt: true,
+};

--- a/server/src/features/articles/article.controller.ts
+++ b/server/src/features/articles/article.controller.ts
@@ -5,10 +5,12 @@ import {
   Get,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
 } from '@nestjs/common';
 import { ArticleService } from './article.service';
 import { ArticleCreateDto } from './dto/article-create.dto';
+import { ArticleEditDto } from './dto/article-edit.dto';
 
 @Controller('articles')
 export class ArticleController {
@@ -31,6 +33,23 @@ export class ArticleController {
     await this.service.createArticle(article);
 
     return { message: 'Article was created successfully' };
+  }
+
+  @Patch('update/:id')
+  async updateArticle(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() partialArticle: ArticleEditDto,
+  ) {
+    await this.service.updateArticle(id, partialArticle);
+
+    return { message: 'Article was soft-deleted successfully' };
+  }
+
+  @Patch('revert-soft-delete/:id')
+  async revertSoftDelete(@Param('id', ParseUUIDPipe) id: string) {
+    await this.service.revertSoftDelete(id);
+
+    return { message: "Article's deletion is reverted" };
   }
 
   @Delete('soft/:id')

--- a/server/src/features/articles/article.controller.ts
+++ b/server/src/features/articles/article.controller.ts
@@ -1,5 +1,14 @@
-import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 import { ArticleService } from './article.service';
+import { ArticleCreateDto } from './dto/article-create.dto';
 
 @Controller('articles')
 export class ArticleController {
@@ -15,5 +24,19 @@ export class ArticleController {
   @Get(':id')
   async findArticleById(@Param('id', ParseUUIDPipe) id: string) {
     return await this.service.findArticleById(id);
+  }
+
+  @Post()
+  async createArticle(@Body() article: ArticleCreateDto) {
+    await this.service.createArticle(article);
+
+    return { message: 'Article was created successfully' };
+  }
+
+  @Delete('soft/:id')
+  async softDelete(@Param('id', ParseUUIDPipe) id: string) {
+    await this.service.softDeleteArticle(id);
+
+    return { message: 'Article was soft-deleted successfully' };
   }
 }

--- a/server/src/features/articles/article.controller.ts
+++ b/server/src/features/articles/article.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ArticleService } from './article.service';
+
+@Controller('articles')
+export class ArticleController {
+  constructor(private service: ArticleService) {}
+
+  // TODO: add querying and page/take params
+  @Get()
+  async findArticles() {
+    return await this.service.findArticles();
+  }
+
+  // TODO: swap UUID with article link
+  @Get(':id')
+  async findArticleById(@Param(ParseUUIDPipe) id: string) {
+    return await this.service.findArticleById(id);
+  }
+}

--- a/server/src/features/articles/article.controller.ts
+++ b/server/src/features/articles/article.controller.ts
@@ -13,7 +13,7 @@ export class ArticleController {
 
   // TODO: swap UUID with article link
   @Get(':id')
-  async findArticleById(@Param(ParseUUIDPipe) id: string) {
+  async findArticleById(@Param('id', ParseUUIDPipe) id: string) {
     return await this.service.findArticleById(id);
   }
 }

--- a/server/src/features/articles/article.entity.ts
+++ b/server/src/features/articles/article.entity.ts
@@ -38,5 +38,5 @@ export class Article {
   updatedAt: Date;
 
   @DeleteDateColumn({ name: 'deleted_at', nullable: true })
-  deletedAt: Date;
+  deletedAt: Date | null;
 }

--- a/server/src/features/articles/article.entity.ts
+++ b/server/src/features/articles/article.entity.ts
@@ -24,6 +24,10 @@ export class Article {
   })
   previewText: string;
 
+  // TODO: replace this column with a separate "paragraphs" table
+  @Column({ length: 2000, nullable: true })
+  text: string;
+
   @Column({ name: 'image_url' })
   imageUrl: string;
 

--- a/server/src/features/articles/article.entity.ts
+++ b/server/src/features/articles/article.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+// TODO: add soft delete
+@Entity('articles')
+export class Article {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({
+    length: 125,
+  })
+  title: string;
+
+  @Column({
+    length: 200,
+    name: 'preview_text',
+    nullable: true,
+  })
+  previewText: string;
+
+  @Column({ name: 'image_url' })
+  imageUrl: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/server/src/features/articles/article.entity.ts
+++ b/server/src/features/articles/article.entity.ts
@@ -1,12 +1,12 @@
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 
-// TODO: add soft delete
 @Entity('articles')
 export class Article {
   @PrimaryGeneratedColumn('uuid')
@@ -34,6 +34,9 @@ export class Article {
   @CreateDateColumn()
   createdAt: Date;
 
-  @UpdateDateColumn()
+  @UpdateDateColumn({ nullable: true })
   updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at', nullable: true })
+  deletedAt: Date;
 }

--- a/server/src/features/articles/article.module.ts
+++ b/server/src/features/articles/article.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Article } from './article.entity';
+import { ArticleController } from './article.controller';
+import { ArticleService } from './article.service';
+import { ArticleRepository } from './artice.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Article])],
+  controllers: [ArticleController],
+  providers: [ArticleService, ArticleRepository],
+})
+export class ArticleModule {}

--- a/server/src/features/articles/article.service.ts
+++ b/server/src/features/articles/article.service.ts
@@ -1,13 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { ArticleRepository } from './artice.repository';
 import { Article } from './article.entity';
+import { plainToInstance } from 'class-transformer';
+import { ArticleShortDto } from './dto/article-short.dto';
 
 @Injectable()
 export class ArticleService {
   constructor(private repo: ArticleRepository) {}
 
-  async findArticles(): Promise<Article[]> {
-    return await this.repo.findArticles();
+  async findArticles(): Promise<ArticleShortDto[]> {
+    const articles = await this.repo.findArticles();
+
+    return plainToInstance(ArticleShortDto, articles);
   }
   async findArticleById(id: string): Promise<Article> {
     return await this.repo.findArticleById(id);

--- a/server/src/features/articles/article.service.ts
+++ b/server/src/features/articles/article.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { ArticleRepository } from './artice.repository';
+import { Article } from './article.entity';
+
+@Injectable()
+export class ArticleService {
+  constructor(private repo: ArticleRepository) {}
+
+  async findArticles(): Promise<Article[]> {
+    return await this.repo.findArticles();
+  }
+  async findArticleById(id: string): Promise<Article> {
+    return await this.repo.findArticleById(id);
+  }
+}

--- a/server/src/features/articles/article.service.ts
+++ b/server/src/features/articles/article.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ArticleRepository } from './artice.repository';
 import { Article } from './article.entity';
 import { plainToInstance } from 'class-transformer';
 import { ArticleShortDto } from './dto/article-short.dto';
 import { ArticleCreateDto } from './dto/article-create.dto';
+import { ArticleEditDto } from './dto/article-edit.dto';
+import { NotNull } from '../../common/constants/database.constants';
 
 @Injectable()
 export class ArticleService {
@@ -19,6 +21,22 @@ export class ArticleService {
   }
   async createArticle(article: ArticleCreateDto): Promise<void> {
     await this.repo.createArticle(article);
+  }
+  async updateArticle(
+    id: string,
+    partialArticle: ArticleEditDto,
+  ): Promise<void> {
+    await this.repo.updateArticle(id, partialArticle);
+  }
+  async revertSoftDelete(id: string): Promise<void> {
+    const isAvailableForRevertion = await this.repo.existsBy({
+      id,
+      deletedAt: NotNull,
+    });
+    if (isAvailableForRevertion)
+      throw new NotFoundException('Such article may already exist/not exist');
+
+    await this.repo.updateArticle(id, { deletedAt: null });
   }
   async softDeleteArticle(id: string): Promise<void> {
     await this.repo.softDeleteArticle(id);

--- a/server/src/features/articles/article.service.ts
+++ b/server/src/features/articles/article.service.ts
@@ -3,6 +3,7 @@ import { ArticleRepository } from './artice.repository';
 import { Article } from './article.entity';
 import { plainToInstance } from 'class-transformer';
 import { ArticleShortDto } from './dto/article-short.dto';
+import { ArticleCreateDto } from './dto/article-create.dto';
 
 @Injectable()
 export class ArticleService {
@@ -15,5 +16,11 @@ export class ArticleService {
   }
   async findArticleById(id: string): Promise<Article> {
     return await this.repo.findArticleById(id);
+  }
+  async createArticle(article: ArticleCreateDto): Promise<void> {
+    await this.repo.createArticle(article);
+  }
+  async softDeleteArticle(id: string): Promise<void> {
+    await this.repo.softDeleteArticle(id);
   }
 }

--- a/server/src/features/articles/dto/article-create.dto.ts
+++ b/server/src/features/articles/dto/article-create.dto.ts
@@ -1,0 +1,26 @@
+import {
+  IsOptional,
+  IsString,
+  IsUrl,
+  Length,
+  MaxLength,
+} from 'class-validator';
+
+export class ArticleCreateDto {
+  @IsString()
+  @Length(25, 125)
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  previewText?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
+  text?: string;
+
+  @IsUrl()
+  imageUrl: string;
+}

--- a/server/src/features/articles/dto/article-edit.dto.ts
+++ b/server/src/features/articles/dto/article-edit.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsOptional,
+  IsString,
+  IsUrl,
+  Length,
+  MaxLength,
+} from 'class-validator';
+
+export class ArticleEditDto {
+  @IsString()
+  @IsOptional()
+  @Length(25, 125)
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  previewText?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
+  text?: string;
+
+  @IsUrl()
+  @IsOptional()
+  imageUrl?: string;
+}

--- a/server/src/features/articles/dto/article-short.dto.ts
+++ b/server/src/features/articles/dto/article-short.dto.ts
@@ -1,0 +1,21 @@
+import { Expose } from 'class-transformer';
+
+export class ArticleShortDto {
+  @Expose()
+  id: string;
+
+  @Expose()
+  title: string;
+
+  @Expose()
+  previewText: string | null;
+
+  @Expose()
+  imageUrl: string;
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  updatedAt: Date | null;
+}

--- a/server/src/features/features.module.ts
+++ b/server/src/features/features.module.ts
@@ -5,6 +5,7 @@ import { CheckModule } from 'features/check/check.module';
 import { PasswordResetModule } from 'features/password-reset/password-reset.module';
 import { RefreshTokenModule } from 'features/refresh-token/refresh-token.module';
 import { UserModule } from 'features/user/user.module';
+import { ArticleModule } from './articles/article.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { UserModule } from 'features/user/user.module';
     AuthModule,
     RefreshTokenModule,
     PasswordResetModule,
+    ArticleModule,
   ],
 })
 export class FeaturesModule {}


### PR DESCRIPTION
# Overview

This module should cover the basic Articles functionality on both BE and FE, adding the ability to query, create, update and **soft** delete articles

## Key additions

- REST routes
  - Article's partial update (to make the request's body smaller)
  - Soft deletion with the ability to revert it (article's removal will be introduced later)
- Articles UI and pages

## Minor changes/fixes
- Introduction of Ky as a replacement for Axios on the client
- Data/error separation hook (`useResponse`)
- Safe routing (defined routes) with params insert (into an object) for client and BE