### PR TITLE
Base statistics

### DIFF
--- a/client/i18n.ts
+++ b/client/i18n.ts
@@ -3,10 +3,11 @@ import { initReactI18next } from 'react-i18next';
 import { TranslationNamespaces } from '@/lib/translation';
 
 import commonEn from '@/assets/locales/en-US/common.json';
-import indexEn from '@/assets/locales/en-US/index.json'
+import indexEn from '@/assets/locales/en-US/index.json';
 import authEn from '@/assets/locales/en-US/auth.json';
 import eventsEn from '@/assets/locales/en-US/events.json';
 import threadsEn from '@/assets/locales/en-US/threads.json';
+import statsEn from '@/assets/locales/en-US/stats.json';
 
 i18n.use(initReactI18next).init({
   fallbackLng: 'en-US',
@@ -20,6 +21,7 @@ i18n.use(initReactI18next).init({
       [TranslationNamespaces.Auth]: authEn,
       [TranslationNamespaces.Events]: eventsEn,
       [TranslationNamespaces.Threads]: threadsEn,
+      [TranslationNamespaces.Statistics]: statsEn,
     },
   },
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,10 @@ import {
   CategoryThreadsPage,
   EventsPage,
   EventsDetailedPade,
+  StatsBasePage,
+  StatsSeasonsPage,
+  StatsSeasonDetailed,
+  StatsEventPage,
 } from '@/pages';
 import { AuthProvider } from '@/providers/AuthProvider';
 import { ThemeProvider } from '@/providers/ThemeProvider';
@@ -85,6 +89,26 @@ function App() {
           // Will be extended later as a profile dashboard
           path: '/me',
           children: [{ index: true, Component: MePage }],
+        },
+        {
+          path: '/stats',
+          children: [
+            { index: true, Component: StatsBasePage },
+            {
+              path: 'seasons',
+              children: [
+                { index: true, Component: StatsSeasonsPage },
+                {
+                  path: ':id',
+                  Component: StatsSeasonDetailed,
+                },
+              ],
+            },
+            {
+              path: 'race-events',
+              children: [{ path: ':id', Component: StatsEventPage }],
+            },
+          ],
         },
       ],
     },

--- a/client/src/api/scopes/stats/race-events.ts
+++ b/client/src/api/scopes/stats/race-events.ts
@@ -1,0 +1,15 @@
+import { api } from '@/api';
+import { backendPath } from '@/lib/routing/backend';
+
+import type { TResponse } from '^/types/response/response.type';
+import type { TRaceEventDetailed } from '^/types/stats/race-events';
+
+export async function getRaceEventById(
+  id: number,
+): Promise<TResponse<TRaceEventDetailed>> {
+  const resp = await api.get<TResponse<TRaceEventDetailed>>(
+    backendPath('RaceEventDetailed', { id }),
+  );
+
+  return await resp.json();
+}

--- a/client/src/api/scopes/stats/race-seasons.ts
+++ b/client/src/api/scopes/stats/race-seasons.ts
@@ -1,0 +1,24 @@
+import { api } from '@/api';
+import { backendPath } from '@/lib/routing/backend';
+
+import type { TResponse } from '^/types/response/response.type';
+import type {
+  TRaceSeasonDetailed,
+  TRaceSeasonShort,
+} from '^/types/stats/race-seasons';
+
+export async function getRaceSeasons(): Promise<TResponse<TRaceSeasonShort[]>> {
+  const resp = await api.get<TResponse<TRaceSeasonShort[]>>(
+    backendPath('RaceSeasons'),
+  );
+
+  return await resp.json();
+}
+
+export async function getRaceSeasonById(id: number) {
+  const resp = await api.get<TResponse<TRaceSeasonDetailed>>(
+    backendPath('RaceSeasonDetailed', { id }),
+  );
+
+  return await resp.json();
+}

--- a/client/src/assets/locales/en-US/common.json
+++ b/client/src/assets/locales/en-US/common.json
@@ -34,7 +34,8 @@
     "sections": {
       "news": "News",
       "events": "Events",
-      "threads": "Threads"
+      "threads": "Threads",
+      "stats": "Statistics"
     }
   },
   "footer": {

--- a/client/src/assets/locales/en-US/stats.json
+++ b/client/src/assets/locales/en-US/stats.json
@@ -1,0 +1,29 @@
+{
+  "common": {
+    "namings": {
+      "season": "{{season}} Season",
+      "stages_one": "{{count}} stage",
+      "stages_other": "{{count}} stages",
+      "laps_one": "{{count}} lap",
+      "laps_other": "{{count}} laps"
+    }
+  },
+  "base": {
+    "title": "Statistics",
+    "description": "Search any info you want",
+    "options": {
+      "seasons": {
+        "title": "Seasons",
+        "description": "Any season of all disciplines"
+      }
+    }
+  },
+  "raceSeasons": {
+    "title": "Race seasons",
+    "description": "Select the needed season of your favorite racing discipline. Filtering included"
+  },
+  "raceEvents": {
+    "title": "Race events",
+    "noEvents": "No race events found in this season"
+  }
+}

--- a/client/src/components/features/stats/race-events/RaceEventItem.tsx
+++ b/client/src/components/features/stats/race-events/RaceEventItem.tsx
@@ -5,6 +5,7 @@ import { Typography } from '@/components/common/typography/Typography';
 import { Pages, path } from '@/lib/routing/client';
 
 import type { TRaceEventShort } from '^/types/stats/race-events';
+import { useTranslation } from '../../../../hooks/useTranslation';
 
 export const RaceEventItem = ({
   id,
@@ -14,30 +15,35 @@ export const RaceEventItem = ({
   circuit,
   startDate,
   endDate,
-}: TRaceEventShort) => (
-  <Link
-    className="flex w-full cursor-pointer flex-col space-y-1 rounded-md border-2 p-3"
-    to={path(Pages.StatisticsRaceDetailed, { id })}
-  >
-    <Typography className="flex" variant="xl">
-      {eventStage}.{' '}
-      <Typography className="ml-1" variant="xl" weight="semibold">
-        {name}
+}: TRaceEventShort) => {
+  const { t } = useTranslation(['stats']);
+
+  return (
+    <Link
+      className="flex w-full cursor-pointer flex-col space-y-1 rounded-md border-2 p-3"
+      to={path(Pages.StatisticsRaceDetailed, { id })}
+    >
+      <Typography className="flex" variant="xl">
+        {eventStage}.{' '}
+        <Typography className="ml-1" variant="xl" weight="semibold">
+          {name}
+        </Typography>
       </Typography>
-    </Typography>
-    <div className="flex space-x-1">
-      <MapPin />
-      <Typography weight="medium">{circuit.name}</Typography>
-      <Typography className="ml-2">
-        {laps} laps ({laps * circuit.length} km)
-      </Typography>
-    </div>
-    <div className="flex">
-      <Calendar />
-      <Typography className="ml-1">
-        {new Date(startDate).toDateString()} -{' '}
-        {new Date(endDate).toDateString()}
-      </Typography>
-    </div>
-  </Link>
-);
+      <div className="flex space-x-1">
+        <MapPin />
+        <Typography weight="medium">{circuit.name}</Typography>
+        <Typography className="ml-2">
+          {t('common.namings.laps', { count: laps })} ({laps * circuit.length}{' '}
+          km)
+        </Typography>
+      </div>
+      <div className="flex">
+        <Calendar />
+        <Typography className="ml-1">
+          {new Date(startDate).toDateString()} -{' '}
+          {new Date(endDate).toDateString()}
+        </Typography>
+      </div>
+    </Link>
+  );
+};

--- a/client/src/components/features/stats/race-events/RaceEventItem.tsx
+++ b/client/src/components/features/stats/race-events/RaceEventItem.tsx
@@ -1,0 +1,43 @@
+import { Calendar, MapPin } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Typography } from '@/components/common/typography/Typography';
+import { Pages, path } from '@/lib/routing/client';
+
+import type { TRaceEventShort } from '^/types/stats/race-events';
+
+export const RaceEventItem = ({
+  id,
+  name,
+  eventStage,
+  laps,
+  circuit,
+  startDate,
+  endDate,
+}: TRaceEventShort) => (
+  <Link
+    className="flex w-full cursor-pointer flex-col space-y-1 rounded-md border-2 p-3"
+    to={path(Pages.StatisticsRaceDetailed, { id })}
+  >
+    <Typography className="flex" variant="xl">
+      {eventStage}.{' '}
+      <Typography className="ml-1" variant="xl" weight="semibold">
+        {name}
+      </Typography>
+    </Typography>
+    <div className="flex space-x-1">
+      <MapPin />
+      <Typography weight="medium">{circuit.name}</Typography>
+      <Typography className="ml-2">
+        {laps} laps ({laps * circuit.length} km)
+      </Typography>
+    </div>
+    <div className="flex">
+      <Calendar />
+      <Typography className="ml-1">
+        {new Date(startDate).toDateString()} -{' '}
+        {new Date(endDate).toDateString()}
+      </Typography>
+    </div>
+  </Link>
+);

--- a/client/src/components/features/stats/race-seasons/RaceSeasonItem.tsx
+++ b/client/src/components/features/stats/race-seasons/RaceSeasonItem.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router';
+
+import { Typography } from '@/components/common/typography/Typography';
+import { Pages, path } from '@/lib/routing/client';
+
+import type { TRaceSeasonShort } from '^/types/stats/race-seasons';
+
+export const RaceSeasonItem = ({
+  id,
+  seasonYear,
+  stages,
+  discipline,
+}: TRaceSeasonShort) => {
+  const { logoUrl, name } = discipline;
+
+  return (
+    <Link
+      className="flex w-full cursor-pointer items-center space-x-3 rounded-md border-2 p-3"
+      to={path(Pages.StatisticsSeasonDetailed, { id })}
+    >
+      <img className="bg-main size-20 rounded-md p-2" src={logoUrl} />
+      <div className="flex flex-col">
+        <Typography variant="xl" weight="semibold">
+          {seasonYear} {name} Season
+        </Typography>
+        <Typography>{stages} stages</Typography>
+      </div>
+    </Link>
+  );
+};

--- a/client/src/components/features/stats/race-seasons/RaceSeasonItem.tsx
+++ b/client/src/components/features/stats/race-seasons/RaceSeasonItem.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router';
 
 import { Typography } from '@/components/common/typography/Typography';
+import { useTranslation } from '@/hooks/useTranslation';
 import { Pages, path } from '@/lib/routing/client';
 
 import type { TRaceSeasonShort } from '^/types/stats/race-seasons';
@@ -11,7 +12,8 @@ export const RaceSeasonItem = ({
   stages,
   discipline,
 }: TRaceSeasonShort) => {
-  const { logoUrl, name } = discipline;
+  const { t } = useTranslation(['stats']);
+  const { logoUrl, name: disciplineName } = discipline;
 
   return (
     <Link
@@ -21,9 +23,11 @@ export const RaceSeasonItem = ({
       <img className="bg-main size-20 rounded-md p-2" src={logoUrl} />
       <div className="flex flex-col">
         <Typography variant="xl" weight="semibold">
-          {seasonYear} {name} Season
+          {t('common.namings.season', {
+            season: `${seasonYear} ${disciplineName}`,
+          })}
         </Typography>
-        <Typography>{stages} stages</Typography>
+        <Typography>{t('common.namings.stages', { count: stages })}</Typography>
       </div>
     </Link>
   );

--- a/client/src/hooks/features/stats/race-events/useRaceEventById.ts
+++ b/client/src/hooks/features/stats/race-events/useRaceEventById.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getRaceEventById } from '@/api/scopes/stats/race-events';
+
+export const useRaceEventById = (id: number) =>
+  useQuery({
+    queryKey: ['race-event', id],
+    queryFn: () => getRaceEventById(id),
+  });

--- a/client/src/hooks/features/stats/race-seasons/useRaceSeasonById.ts
+++ b/client/src/hooks/features/stats/race-seasons/useRaceSeasonById.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getRaceSeasonById } from '@/api/scopes/stats/race-seasons';
+
+export const useRaceSeasonById = (id: number) =>
+  useQuery({
+    queryKey: ['race-season', id],
+    queryFn: () => getRaceSeasonById(id),
+  });

--- a/client/src/hooks/features/stats/race-seasons/useRaceSeasons.ts
+++ b/client/src/hooks/features/stats/race-seasons/useRaceSeasons.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getRaceSeasons } from '@/api/scopes/stats/race-seasons';
+
+export const useRaceSeasons = () =>
+  useQuery({
+    queryKey: ['race-seasons'],
+    queryFn: getRaceSeasons,
+  });

--- a/client/src/lib/routing/backend.ts
+++ b/client/src/lib/routing/backend.ts
@@ -32,6 +32,11 @@ export const BackendRoutes = {
 
   // Comment routes
   CommentsBase: 'comments',
+
+  // Statistics routes
+  RaceSeasons: 'race-seasons',
+  RaceSeasonDetailed: 'race-seasons/:id',
+  RaceEventDetailed: 'race-events/:id',
 } as const;
 
 type RoutesKeys = keyof typeof BackendRoutes;

--- a/client/src/lib/routing/client.ts
+++ b/client/src/lib/routing/client.ts
@@ -14,9 +14,13 @@ export const Pages = {
   UserProfile: '/users/:id',
 
   Profile: '/me',
+
+  StatisticsBase: '/stats',
+  StatisticsSeasons: '/stats/seasons',
+  StatisticsSeasonDetailed: '/stats/seasons/:id',
+  StatisticsRaceDetailed: '/stats/race-events/:id',
 } as const;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type Params = Record<string, string | number>;
 
 export const NAV_ROUTES = [
@@ -31,6 +35,10 @@ export const NAV_ROUTES = [
   {
     id: 'threads',
     route: Pages.ThreadsIndex,
+  },
+  {
+    id: 'stats',
+    route: Pages.StatisticsBase,
   },
 ] as const;
 

--- a/client/src/lib/translation/index.ts
+++ b/client/src/lib/translation/index.ts
@@ -4,6 +4,7 @@ export const TranslationNamespaces = {
   Auth: 'auth',
   Events: 'events',
   Threads: 'threads',
+  Statistics: 'stats',
 } as const;
 
 export type TranslationNamespace =

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -22,4 +22,10 @@ export { CategoryThreadsPage } from './threads/category-threads';
 // User pages
 export { UserProfilePage } from './users/profile';
 
+// Statistics pages
+export { StatsBasePage } from './stats/StatsBasePage';
+export { StatsSeasonsPage } from './stats/StatsSeasonsPage';
+export { StatsSeasonDetailed } from './stats/StatsSeasonDetailed';
+export { StatsEventPage } from './stats/StatsEventPage';
+
 export { MePage } from './me/MePage';

--- a/client/src/pages/stats/StatsBasePage.tsx
+++ b/client/src/pages/stats/StatsBasePage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router';
 
 import { Typography } from '@/components/common/typography/Typography';
+import { useTranslation } from '@/hooks/useTranslation';
 import { Pages } from '@/lib/routing/client';
 
 const StatAreaNav = ({
@@ -28,16 +29,18 @@ const StatAreaNav = ({
 };
 
 export const StatsBasePage = () => {
+  const { t } = useTranslation(['stats']);
+
   return (
     <div className="flex w-full flex-col space-y-1">
       <Typography variant="3xl" weight="semibold">
-        Statistics
+        {t('base.title')}
       </Typography>
-      <Typography variant="lg">Search any info you want</Typography>
+      <Typography variant="lg">{t('base.description')}</Typography>
       <div className="mt-2 flex flex-col md:grid md:grid-cols-2">
         <StatAreaNav
-          title="Seasons"
-          description="Any season of all disciplines"
+          title={t('base.options.seasons.title')}
+          description={t('base.options.seasons.description')}
           route={Pages.StatisticsSeasons}
         />
       </div>

--- a/client/src/pages/stats/StatsBasePage.tsx
+++ b/client/src/pages/stats/StatsBasePage.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router';
+
+import { Typography } from '@/components/common/typography/Typography';
+import { Pages } from '@/lib/routing/client';
+
+const StatAreaNav = ({
+  title,
+  description,
+  route,
+}: {
+  title: string;
+  description: string;
+  route: string;
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="flex w-full cursor-pointer flex-col items-center space-y-1 rounded-md border-2 py-2 *:select-none"
+      onClick={() => navigate(route)}
+    >
+      <Typography variant="2xl" weight="semibold">
+        {title}
+      </Typography>
+      <Typography variant="lg">{description}</Typography>
+    </div>
+  );
+};
+
+export const StatsBasePage = () => {
+  return (
+    <div className="flex w-full flex-col space-y-1">
+      <Typography variant="3xl" weight="semibold">
+        Statistics
+      </Typography>
+      <Typography variant="lg">Search any info you want</Typography>
+      <div className="mt-2 flex flex-col md:grid md:grid-cols-2">
+        <StatAreaNav
+          title="Seasons"
+          description="Any season of all disciplines"
+          route={Pages.StatisticsSeasons}
+        />
+      </div>
+    </div>
+  );
+};

--- a/client/src/pages/stats/StatsEventPage.tsx
+++ b/client/src/pages/stats/StatsEventPage.tsx
@@ -3,13 +3,15 @@ import { Link, useParams } from 'react-router';
 
 import { CenteredSpinner } from '@/components/common/spinner/CenteredSpinner';
 import { Typography } from '@/components/common/typography/Typography';
-import { Pages, path } from '@/lib/routing/client';
 import { useRaceEventById } from '@/hooks/features/stats/race-events/useRaceEventById';
 import { useResponse } from '@/hooks/useResponse';
+import { useTranslation } from '@/hooks/useTranslation';
+import { Pages, path } from '@/lib/routing/client';
 
 export const StatsEventPage = () => {
   const { id } = useParams();
   const { data: eventRes, isLoading } = useRaceEventById(Number(id || 0));
+  const { t } = useTranslation(['stats']);
 
   const { data: event } = useResponse(eventRes);
 
@@ -37,7 +39,8 @@ export const StatsEventPage = () => {
           <MapPin />
           <Typography weight="medium">{event.circuit.name}</Typography>
           <Typography className="ml-2">
-            {event.laps} laps ({Number(event.laps) * event.circuit.length} km)
+            {t('common.namings.laps', { count: event.laps })} (
+            {Number(event.laps) * event.circuit.length} km)
           </Typography>
         </div>
 
@@ -51,7 +54,9 @@ export const StatsEventPage = () => {
 
         {event.season && (
           <div className="flex items-center space-x-2">
-            <Typography>Season:</Typography>
+            <Typography>
+              {t('common.namings.season', { season: null })}:
+            </Typography>
             <Link
               className="flex items-center space-x-1 md:space-x-2"
               to={path(Pages.StatisticsSeasonDetailed, { id: event.season.id })}

--- a/client/src/pages/stats/StatsEventPage.tsx
+++ b/client/src/pages/stats/StatsEventPage.tsx
@@ -1,0 +1,72 @@
+import { Calendar, MapPin } from 'lucide-react';
+import { Link, useParams } from 'react-router';
+
+import { CenteredSpinner } from '@/components/common/spinner/CenteredSpinner';
+import { Typography } from '@/components/common/typography/Typography';
+import { Pages, path } from '@/lib/routing/client';
+import { useRaceEventById } from '@/hooks/features/stats/race-events/useRaceEventById';
+import { useResponse } from '@/hooks/useResponse';
+
+export const StatsEventPage = () => {
+  const { id } = useParams();
+  const { data: eventRes, isLoading } = useRaceEventById(Number(id || 0));
+
+  const { data: event } = useResponse(eventRes);
+
+  if (isLoading || !event) return <CenteredSpinner />;
+
+  return (
+    <div className="flex flex-col space-y-4 lg:w-3/5">
+      <div>
+        <Typography className="flex" variant="2xl" weight="semibold">
+          {event.eventStage}.{' '}
+          <Typography className="ml-1" variant="2xl" weight="semibold">
+            {event.name}
+          </Typography>
+        </Typography>
+      </div>
+
+      {event.description && (
+        <div>
+          <Typography>{event.description}</Typography>
+        </div>
+      )}
+
+      <div className="flex flex-col space-y-2">
+        <div className="flex items-center space-x-2">
+          <MapPin />
+          <Typography weight="medium">{event.circuit.name}</Typography>
+          <Typography className="ml-2">
+            {event.laps} laps ({Number(event.laps) * event.circuit.length} km)
+          </Typography>
+        </div>
+
+        <div className="flex items-center">
+          <Calendar />
+          <Typography className="ml-2">
+            {new Date(event.startDate).toDateString()} -{' '}
+            {new Date(event.endDate).toDateString()}
+          </Typography>
+        </div>
+
+        {event.season && (
+          <div className="flex items-center space-x-2">
+            <Typography>Season:</Typography>
+            <Link
+              className="flex items-center space-x-1 md:space-x-2"
+              to={path(Pages.StatisticsSeasonDetailed, { id: event.season.id })}
+            >
+              <img
+                className="bg-main size-12 rounded-sm p-1"
+                src={event.season.discipline.logoUrl}
+              />
+              <Typography weight="semibold">
+                {event.season.seasonYear} {event.season.discipline.name}
+              </Typography>
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/client/src/pages/stats/StatsSeasonDetailed.tsx
+++ b/client/src/pages/stats/StatsSeasonDetailed.tsx
@@ -5,10 +5,12 @@ import { Typography } from '@/components/common/typography/Typography';
 import { RaceEventItem } from '@/components/features/stats/race-events/RaceEventItem';
 import { useRaceSeasonById } from '@/hooks/features/stats/race-seasons/useRaceSeasonById';
 import { useResponse } from '@/hooks/useResponse';
+import { useTranslation } from '@/hooks/useTranslation';
 
 export const StatsSeasonDetailed = () => {
   const { id } = useParams();
   const { data: seasonRes, isLoading } = useRaceSeasonById(Number(id || 0));
+  const { t } = useTranslation(['stats']);
 
   const { data: season } = useResponse(seasonRes);
 
@@ -23,10 +25,14 @@ export const StatsSeasonDetailed = () => {
         />
         <div className="space-y-0.5">
           <Typography variant="2xl" weight="semibold">
-            {season.seasonYear} {season.discipline.name} Season
+            {t('common.namings.season', {
+              season: `${season.seasonYear} ${season.discipline.name}`,
+            })}
           </Typography>
           <div className="space-x-2">
-            <Typography variant="lg">{season.stages} stages</Typography>
+            <Typography variant="lg">
+              {t('common.namings.stages', { count: season.stages })}
+            </Typography>
             <Typography
               className="bg-main rounded-xl px-1.5 py-1 text-white"
               weight="semibold"
@@ -38,11 +44,11 @@ export const StatsSeasonDetailed = () => {
       </div>
       <div className="space-y-2">
         <Typography variant="2xl" weight="semibold">
-          Race events
+          {t('raceEvents.title')}
         </Typography>
         <div className="flex flex-col space-y-2">
           {!season.raceEvents.length && (
-            <Typography>No race events found in this season</Typography>
+            <Typography>{t('raceEvents.noEvents')}</Typography>
           )}
           {season.raceEvents.map((re) => (
             <RaceEventItem key={re.id} {...re} />

--- a/client/src/pages/stats/StatsSeasonDetailed.tsx
+++ b/client/src/pages/stats/StatsSeasonDetailed.tsx
@@ -1,0 +1,54 @@
+import { useParams } from 'react-router';
+
+import { CenteredSpinner } from '@/components/common/spinner/CenteredSpinner';
+import { Typography } from '@/components/common/typography/Typography';
+import { RaceEventItem } from '@/components/features/stats/race-events/RaceEventItem';
+import { useRaceSeasonById } from '@/hooks/features/stats/race-seasons/useRaceSeasonById';
+import { useResponse } from '@/hooks/useResponse';
+
+export const StatsSeasonDetailed = () => {
+  const { id } = useParams();
+  const { data: seasonRes, isLoading } = useRaceSeasonById(Number(id || 0));
+
+  const { data: season } = useResponse(seasonRes);
+
+  if (isLoading || !season) return <CenteredSpinner />;
+
+  return (
+    <div className="flex flex-col space-y-4 lg:w-3/5">
+      <div className="flex items-center space-x-3">
+        <img
+          className="bg-main size-20 rounded-md p-2"
+          src={season.discipline.logoUrl}
+        />
+        <div className="space-y-0.5">
+          <Typography variant="2xl" weight="semibold">
+            {season.seasonYear} {season.discipline.name} Season
+          </Typography>
+          <div className="space-x-2">
+            <Typography variant="lg">{season.stages} stages</Typography>
+            <Typography
+              className="bg-main rounded-xl px-1.5 py-1 text-white"
+              weight="semibold"
+            >
+              {season.discipline.name}
+            </Typography>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Typography variant="2xl" weight="semibold">
+          Race events
+        </Typography>
+        <div className="flex flex-col space-y-2">
+          {!season.raceEvents.length && (
+            <Typography>No race events found in this season</Typography>
+          )}
+          {season.raceEvents.map((re) => (
+            <RaceEventItem key={re.id} {...re} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/client/src/pages/stats/StatsSeasonsPage.tsx
+++ b/client/src/pages/stats/StatsSeasonsPage.tsx
@@ -1,0 +1,31 @@
+import { Typography } from '@/components/common/typography/Typography';
+import { RaceSeasonItem } from '@/components/features/stats/race-seasons/RaceSeasonItem';
+import { useRaceSeasons } from '@/hooks/features/stats/race-seasons/useRaceSeasons';
+import { useResponse } from '@/hooks/useResponse';
+
+export const StatsSeasonsPage = () => {
+  const { data: seasonsRes } = useRaceSeasons();
+
+  const { data: seasons } = useResponse(seasonsRes);
+
+  return (
+    <div className="flex w-full flex-col space-y-2">
+      <div className="flex flex-col space-y-1">
+        <Typography variant="3xl" weight="semibold">
+          Race seasons
+        </Typography>
+        <Typography variant="lg">
+          Select the needed season of your favorite racing discipline. Filtering
+          included
+        </Typography>
+      </div>
+      {seasons && (
+        <div className="space-y-3 md:grid md:grid-cols-2 md:space-y-0 md:gap-x-4 lg:grid-cols-3">
+          {seasons.map((season) => (
+            <RaceSeasonItem key={season.id} {...season} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/src/pages/stats/StatsSeasonsPage.tsx
+++ b/client/src/pages/stats/StatsSeasonsPage.tsx
@@ -2,9 +2,11 @@ import { Typography } from '@/components/common/typography/Typography';
 import { RaceSeasonItem } from '@/components/features/stats/race-seasons/RaceSeasonItem';
 import { useRaceSeasons } from '@/hooks/features/stats/race-seasons/useRaceSeasons';
 import { useResponse } from '@/hooks/useResponse';
+import { useTranslation } from '@/hooks/useTranslation';
 
 export const StatsSeasonsPage = () => {
   const { data: seasonsRes } = useRaceSeasons();
+  const { t } = useTranslation(['stats']);
 
   const { data: seasons } = useResponse(seasonsRes);
 
@@ -12,12 +14,9 @@ export const StatsSeasonsPage = () => {
     <div className="flex w-full flex-col space-y-2">
       <div className="flex flex-col space-y-1">
         <Typography variant="3xl" weight="semibold">
-          Race seasons
+          {t('raceSeasons.title')}
         </Typography>
-        <Typography variant="lg">
-          Select the needed season of your favorite racing discipline. Filtering
-          included
-        </Typography>
+        <Typography variant="lg">{t('raceSeasons.description')}</Typography>
       </div>
       {seasons && (
         <div className="space-y-3 md:grid md:grid-cols-2 md:space-y-0 md:gap-x-4 lg:grid-cols-3">

--- a/client/utils/types/circuits.ts
+++ b/client/utils/types/circuits.ts
@@ -1,0 +1,9 @@
+export type TCircuitShort = {
+  id: number;
+  name: string;
+  length: number;
+};
+
+export type TCircuitReference = TCircuitShort & {
+  location: string;
+};

--- a/client/utils/types/stats/race-classification.ts
+++ b/client/utils/types/stats/race-classification.ts
@@ -1,4 +1,4 @@
-import { TRaceEntry } from '^/types/stats/race-entry';
+import { TRaceEntry } from './race-entry';
 
 export type TRaceClassification = {
   id: number;

--- a/client/utils/types/stats/race-classification.ts
+++ b/client/utils/types/stats/race-classification.ts
@@ -1,0 +1,10 @@
+import { TRaceEntry } from '^/types/stats/race-entry';
+
+export type TRaceClassification = {
+  id: number;
+  timeMs: number;
+  finishPosition: number;
+  isFastestLap: boolean;
+  earlyEndResult: string | null;
+  raceEntry: TRaceEntry;
+};

--- a/client/utils/types/stats/race-entry.ts
+++ b/client/utils/types/stats/race-entry.ts
@@ -1,0 +1,6 @@
+export type TRaceEntry = {
+  id: number;
+  name: string;
+  entryNumber: number;
+  car: string;
+};

--- a/client/utils/types/stats/race-events.ts
+++ b/client/utils/types/stats/race-events.ts
@@ -15,7 +15,7 @@ export type TRaceEventDetailed = {
   id: number;
   name: string;
   description: string;
-  laps: string;
+  laps: number;
   eventStage: string;
   startDate: string;
   endDate: string;

--- a/client/utils/types/stats/race-events.ts
+++ b/client/utils/types/stats/race-events.ts
@@ -1,0 +1,24 @@
+import type { TCircuitReference, TCircuitShort } from '^/types/circuits';
+import type { TRaceSeasonDetailed } from '^/types/stats/race-seasons';
+
+export type TRaceEventShort = {
+  id: number;
+  name: string;
+  laps: number;
+  eventStage: 1;
+  startDate: string;
+  endDate: string;
+  circuit: TCircuitShort;
+};
+
+export type TRaceEventDetailed = {
+  id: number;
+  name: string;
+  description: string;
+  laps: string;
+  eventStage: string;
+  startDate: string;
+  endDate: string;
+  circuit: TCircuitReference;
+  season: Omit<TRaceSeasonDetailed, 'raceEvents'>;
+};

--- a/client/utils/types/stats/race-seasons.ts
+++ b/client/utils/types/stats/race-seasons.ts
@@ -1,0 +1,25 @@
+import type { TRaceEventShort } from '^/types/stats/race-events';
+
+export type TRaceSeasonShort = {
+  id: number;
+  seasonYear: number;
+  stages: number;
+  discipline: {
+    id: number;
+    name: string;
+    logoUrl: string;
+  };
+};
+
+export type TRaceSeasonDetailed = {
+  id: number;
+  seasonYear: number;
+  stages: number;
+  discipline: {
+    id: number;
+    name: string;
+    shortCode: string;
+    logoUrl: string;
+  };
+  raceEvents: TRaceEventShort[];
+};

--- a/server/src/features/circuits/circuit.entity.ts
+++ b/server/src/features/circuits/circuit.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('circuits')
+export class CircuitEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index('circuit_name_idx')
+  @Column({ type: 'text' })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'text' })
+  location: string;
+
+  @Column()
+  capacity: number;
+
+  @Column({ type: 'numeric', scale: 3 })
+  length: number;
+
+  @Column({ name: 'other_names', type: 'text', array: true, default: [] })
+  otherNames: string[];
+}

--- a/server/src/features/circuits/circuit.module.ts
+++ b/server/src/features/circuits/circuit.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CircuitEntity } from 'features/circuits/circuit.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CircuitEntity])],
+})
+export class CircuitModule {}

--- a/server/src/features/circuits/dto/circuit-short.dto.ts
+++ b/server/src/features/circuits/dto/circuit-short.dto.ts
@@ -1,0 +1,16 @@
+import { Expose, Type } from 'class-transformer';
+
+export class CircuitShortDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  location: string;
+
+  @Expose()
+  @Type(() => Number)
+  length: number;
+}

--- a/server/src/features/circuits/dto/index.ts
+++ b/server/src/features/circuits/dto/index.ts
@@ -1,0 +1,1 @@
+export { CircuitShortDto } from './circuit-short.dto';

--- a/server/src/features/disciplines/discipline.controller.ts
+++ b/server/src/features/disciplines/discipline.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+
+import { PaginatedQuery } from 'common/types/pagination.type';
+
+import { DisciplineService } from 'features/disciplines/discipline.service';
+
+@Controller('disciplines')
+export class DisciplineController {
+  constructor(private service: DisciplineService) {}
+
+  @Get()
+  async getDisciplines(@Query() query: PaginatedQuery) {
+    const [items, totalCount] = await this.service.getDisciplines(query);
+
+    return {
+      items,
+      totalCount,
+      query: {
+        page: query.page,
+        perPage: query.take,
+      },
+    };
+  }
+
+  @Get(':code')
+  async getDisciplineByCode(@Param('code') code: string) {
+    return this.service.getDisciplineByCode(code);
+  }
+}

--- a/server/src/features/disciplines/discipline.entity.ts
+++ b/server/src/features/disciplines/discipline.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('disciplines')
+export class DisciplineEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'text' })
+  name: string;
+
+  @Index('discipline_shortCode_idx')
+  @Column({ name: 'short_code', length: 15 })
+  shortCode: string;
+
+  @Column({ name: 'logo_url', type: 'text' })
+  logoUrl: string;
+}

--- a/server/src/features/disciplines/discipline.module.ts
+++ b/server/src/features/disciplines/discipline.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { DisciplineController } from 'features/disciplines/discipline.controller';
+import { DisciplineEntity } from 'features/disciplines/discipline.entity';
+import { DisciplineRepository } from 'features/disciplines/discipline.repository';
+import { DisciplineService } from 'features/disciplines/discipline.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DisciplineEntity])],
+  controllers: [DisciplineController],
+  providers: [DisciplineService, DisciplineRepository],
+})
+export class DisciplineModule {}

--- a/server/src/features/disciplines/discipline.repository.ts
+++ b/server/src/features/disciplines/discipline.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { DisciplineEntity } from 'features/disciplines/discipline.entity';
+
+@Injectable()
+export class DisciplineRepository {
+  constructor(
+    @InjectRepository(DisciplineEntity)
+    private repo: Repository<DisciplineEntity>,
+  ) {}
+
+  async getDisciplines(
+    page: number = 1,
+    take: number = 10,
+  ): Promise<[DisciplineEntity[], number]> {
+    return this.repo.findAndCount({
+      order: {
+        name: 'ASC',
+      },
+      take,
+      skip: (page - 1) * 10,
+    });
+  }
+
+  async getDisciplineByCode(code: string): Promise<DisciplineEntity | null> {
+    return this.repo.findOne({
+      where: {
+        shortCode: code,
+      },
+    });
+  }
+}

--- a/server/src/features/disciplines/discipline.service.ts
+++ b/server/src/features/disciplines/discipline.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { PaginatedQuery } from 'common/types/pagination.type';
+
+import { DisciplineEntity } from 'features/disciplines/discipline.entity';
+import { DisciplineRepository } from 'features/disciplines/discipline.repository';
+
+@Injectable()
+export class DisciplineService {
+  constructor(private repo: DisciplineRepository) {}
+
+  async getDisciplines(
+    pagination: PaginatedQuery,
+  ): Promise<[DisciplineEntity[], number]> {
+    return this.repo.getDisciplines(pagination.page, pagination.take);
+  }
+
+  async getDisciplineByCode(code: string): Promise<DisciplineEntity> {
+    const discipline = await this.repo.getDisciplineByCode(code);
+    if (!discipline)
+      throw new NotFoundException('Such discipline does not exist');
+
+    return discipline;
+  }
+}

--- a/server/src/features/disciplines/dto/discipline.dto.ts
+++ b/server/src/features/disciplines/dto/discipline.dto.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+
+export class DisciplineDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  shortCode: string;
+
+  @Expose()
+  logoUrl: string;
+}

--- a/server/src/features/disciplines/dto/index.ts
+++ b/server/src/features/disciplines/dto/index.ts
@@ -1,0 +1,1 @@
+export { DisciplineDto } from './discipline.dto';

--- a/server/src/features/features.module.ts
+++ b/server/src/features/features.module.ts
@@ -7,6 +7,7 @@ import { CommentModule } from 'features/comments/comment.module';
 import { DisciplineModule } from 'features/disciplines/discipline.module';
 import { EventModule } from 'features/events/event.module';
 import { PasswordResetModule } from 'features/password-reset/password-reset.module';
+import { StatisticsModule } from 'features/statistics/statistics.module';
 import { ThreadModule } from 'features/threads/thread.module';
 import { ThreadCategoryModule } from 'features/thread-categories/thread-category.module';
 import { UserModule } from 'features/user/user.module';
@@ -23,6 +24,7 @@ import { UserModule } from 'features/user/user.module';
     EventModule,
     CommentModule,
     DisciplineModule,
+    StatisticsModule,
   ],
 })
 export class FeaturesModule {}

--- a/server/src/features/features.module.ts
+++ b/server/src/features/features.module.ts
@@ -4,6 +4,7 @@ import { ArticleModule } from 'features/articles/article.module';
 import { AuthModule } from 'features/auth/auth.module';
 import { CheckModule } from 'features/check/check.module';
 import { CommentModule } from 'features/comments/comment.module';
+import { DisciplineModule } from 'features/disciplines/discipline.module';
 import { EventModule } from 'features/events/event.module';
 import { PasswordResetModule } from 'features/password-reset/password-reset.module';
 import { ThreadModule } from 'features/threads/thread.module';
@@ -21,6 +22,7 @@ import { UserModule } from 'features/user/user.module';
     ThreadCategoryModule,
     EventModule,
     CommentModule,
+    DisciplineModule,
   ],
 })
 export class FeaturesModule {}

--- a/server/src/features/features.module.ts
+++ b/server/src/features/features.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ArticleModule } from 'features/articles/article.module';
 import { AuthModule } from 'features/auth/auth.module';
 import { CheckModule } from 'features/check/check.module';
+import { CircuitModule } from 'features/circuits/circuit.module';
 import { CommentModule } from 'features/comments/comment.module';
 import { DisciplineModule } from 'features/disciplines/discipline.module';
 import { EventModule } from 'features/events/event.module';
@@ -25,6 +26,7 @@ import { UserModule } from 'features/user/user.module';
     CommentModule,
     DisciplineModule,
     StatisticsModule,
+    CircuitModule,
   ],
 })
 export class FeaturesModule {}

--- a/server/src/features/statistics/race-classifications/race-classification.entity.ts
+++ b/server/src/features/statistics/race-classifications/race-classification.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { RaceEarlyEndReason } from 'features/statistics/race-classifications/types/race-early-end-reason.enum';
+import { RaceEntryEntity } from 'features/statistics/race-entries/race-entry.entity';
+import { RaceEventEntity } from 'features/statistics/race-events/race-event.entity';
+
+@Entity('race_classifications')
+@Index(
+  'unique_position_entry_event_idx',
+  ['finishPosition', 'raceEntry', 'raceEvent'],
+  { unique: true },
+)
+export class RaceClassificationEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'integer' })
+  timeMs: number;
+
+  @Column({ name: 'finish_position', nullable: true })
+  finishPosition: number;
+
+  @Column({ name: 'is_fastest_lap', nullable: false })
+  isFastestLap: boolean;
+
+  @Column({
+    name: 'early_end_reason',
+    type: 'enum',
+    enum: RaceEarlyEndReason,
+    nullable: true,
+  })
+  earlyEndReason: RaceEarlyEndReason;
+
+  @ManyToOne(() => RaceEntryEntity, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'race_entry_id' })
+  raceEntry: RaceEntryEntity;
+
+  @ManyToOne(() => RaceEventEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'race_event_id' })
+  raceEvent: RaceEventEntity;
+}

--- a/server/src/features/statistics/race-classifications/race-classification.module.ts
+++ b/server/src/features/statistics/race-classifications/race-classification.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RaceClassificationEntity } from 'features/statistics/race-classifications/race-classification.entity';
+import { RaceClassificationRepository } from 'features/statistics/race-classifications/race-classification.repository';
+import { RaceClassificationService } from 'features/statistics/race-classifications/race-classification.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RaceClassificationEntity])],
+  providers: [RaceClassificationService, RaceClassificationRepository],
+  exports: [RaceClassificationService],
+})
+export class RaceClassificationModule {}

--- a/server/src/features/statistics/race-classifications/race-classification.repository.ts
+++ b/server/src/features/statistics/race-classifications/race-classification.repository.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { RaceClassificationEntity } from 'features/statistics/race-classifications/race-classification.entity';
+
+@Injectable()
+export class RaceClassificationRepository {
+  constructor(
+    @InjectRepository(RaceClassificationEntity)
+    private repo: Repository<RaceClassificationEntity>,
+  ) {}
+
+  async getClassificationsForRaceEvent(
+    raceEventId: number,
+  ): Promise<RaceClassificationEntity[]> {
+    return this.repo.find({
+      where: { raceEvent: { id: raceEventId } },
+      order: {
+        finishPosition: 'ASC',
+      },
+      relations: ['raceEntry'],
+    });
+  }
+}

--- a/server/src/features/statistics/race-classifications/race-classification.service.ts
+++ b/server/src/features/statistics/race-classifications/race-classification.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+
+import { RaceClassificationRepository } from 'features/statistics/race-classifications/race-classification.repository';
+
+@Injectable()
+export class RaceClassificationService {
+  constructor(private repo: RaceClassificationRepository) {}
+
+  async getClassificationsForRaceEvent(raceEventId: number) {
+    return this.repo.getClassificationsForRaceEvent(raceEventId);
+  }
+}

--- a/server/src/features/statistics/race-classifications/types/race-early-end-reason.enum.ts
+++ b/server/src/features/statistics/race-classifications/types/race-early-end-reason.enum.ts
@@ -1,0 +1,5 @@
+export enum RaceEarlyEndReason {
+  DISQUALIFIED = 'DSQ',
+  DID_NOT_START = 'DNS',
+  DID_NOT_FINISH = 'DNF',
+}

--- a/server/src/features/statistics/race-entries/race-entry.entity.ts
+++ b/server/src/features/statistics/race-entries/race-entry.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { DisciplineEntity } from 'features/disciplines/discipline.entity';
+import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
+
+@Entity('race_entries')
+@Index('unique_entryNumber_season_idx', ['entryNumber', 'season'], {
+  unique: true,
+})
+export class RaceEntryEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'text' })
+  name: string;
+
+  @Column({ name: 'entry_number' })
+  entryNumber: number;
+
+  @Column({ type: 'text' })
+  car: string;
+
+  @ManyToOne(() => RaceSeasonEntity)
+  @JoinColumn({ name: 'season_id' })
+  season: RaceSeasonEntity;
+
+  @ManyToOne(() => DisciplineEntity)
+  @JoinColumn({ name: 'discipline_id' })
+  discipline: DisciplineEntity;
+}

--- a/server/src/features/statistics/race-entries/race-entry.module.ts
+++ b/server/src/features/statistics/race-entries/race-entry.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RaceEntryEntity } from 'features/statistics/race-entries/race-entry.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RaceEntryEntity])],
+})
+export class RaceEntryModule {}

--- a/server/src/features/statistics/race-events/constants/race-events.constants.ts
+++ b/server/src/features/statistics/race-events/constants/race-events.constants.ts
@@ -1,0 +1,30 @@
+export const RACE_EVENT_MANY_SELECT_BY_SEASON = {
+  id: true,
+  name: true,
+  laps: true,
+  eventStage: true,
+  startDate: true,
+  endDate: true,
+  circuit: {
+    id: true,
+    name: true,
+    length: true,
+  },
+};
+
+export const RACE_EVENT_ONE_SELECT = {
+  id: true,
+  name: true,
+  description: true,
+  laps: true,
+  eventStage: true,
+  startDate: true,
+  endDate: true,
+  circuit: {
+    id: true,
+    name: true,
+    length: true,
+    location: true,
+  },
+  season: true,
+};

--- a/server/src/features/statistics/race-events/dto/index.ts
+++ b/server/src/features/statistics/race-events/dto/index.ts
@@ -1,0 +1,2 @@
+export { RaceEventDetailedDto } from './race-event-detailed.dto';
+export { RaceEventShortDto } from './race-event-short.dto';

--- a/server/src/features/statistics/race-events/dto/race-event-detailed.dto.ts
+++ b/server/src/features/statistics/race-events/dto/race-event-detailed.dto.ts
@@ -1,0 +1,35 @@
+import { Expose, Type } from 'class-transformer';
+
+import { CircuitShortDto } from 'features/circuits/dto';
+import { RaceSeasonDto } from 'features/statistics/race-seasons/dto';
+
+export class RaceEventDetailedDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  description: string;
+
+  @Expose()
+  laps: string;
+
+  @Expose()
+  eventStage: string;
+
+  @Expose()
+  startDate: Date;
+
+  @Expose()
+  endDate: Date;
+
+  @Expose()
+  @Type(() => CircuitShortDto)
+  circuit: CircuitShortDto;
+
+  @Expose()
+  @Type(() => RaceSeasonDto)
+  season: RaceSeasonDto;
+}

--- a/server/src/features/statistics/race-events/dto/race-event-short.dto.ts
+++ b/server/src/features/statistics/race-events/dto/race-event-short.dto.ts
@@ -1,0 +1,36 @@
+import { Expose, Type } from 'class-transformer';
+
+export class RaceEventShortDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  laps: string;
+
+  @Expose()
+  eventStage: string;
+
+  @Expose()
+  startDate: Date;
+
+  @Expose()
+  endDate: Date;
+
+  @Expose()
+  @Type(() => CircuitShorterDto)
+  circuit: CircuitShorterDto;
+}
+
+class CircuitShorterDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  location: string;
+}

--- a/server/src/features/statistics/race-events/dto/race-event-short.dto.ts
+++ b/server/src/features/statistics/race-events/dto/race-event-short.dto.ts
@@ -1,5 +1,16 @@
 import { Expose, Type } from 'class-transformer';
 
+class CircuitShorterDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  location: string;
+}
+
 export class RaceEventShortDto {
   @Expose()
   id: number;
@@ -22,15 +33,4 @@ export class RaceEventShortDto {
   @Expose()
   @Type(() => CircuitShorterDto)
   circuit: CircuitShorterDto;
-}
-
-class CircuitShorterDto {
-  @Expose()
-  id: number;
-
-  @Expose()
-  name: string;
-
-  @Expose()
-  location: string;
 }

--- a/server/src/features/statistics/race-events/race-event.controller.ts
+++ b/server/src/features/statistics/race-events/race-event.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+
+import { RaceEventService } from 'features/statistics/race-events/race-event.service';
+
+@Controller('race-events')
+export class RaceEventController {
+  constructor(private service: RaceEventService) {}
+
+  @Get(':id')
+  async getRaceEventById(@Param('id', ParseIntPipe) id: number) {
+    return this.service.getRaceEventById(id);
+  }
+
+  @Get('by-season/:id')
+  async getRaceEventsBySeason(@Param('id', ParseIntPipe) id: number) {
+    return this.service.getRaceEventsBySeason(id);
+  }
+}

--- a/server/src/features/statistics/race-events/race-event.entity.ts
+++ b/server/src/features/statistics/race-events/race-event.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { CircuitEntity } from 'features/circuits/circuit.entity';
+import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
+
+@Entity('race_events')
+export class RaceEventEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'text' })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column()
+  laps: number;
+
+  @Column({ name: 'event_stage' })
+  eventStage: number;
+
+  @Column({
+    name: 'start_date',
+    type: 'timestamptz',
+    precision: 0,
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  startDate: Date;
+
+  @Column({
+    name: 'end_date',
+    type: 'timestamptz',
+    precision: 0,
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  endDate: Date;
+
+  @ManyToOne(() => CircuitEntity, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'circuit_id' })
+  circuit: CircuitEntity;
+
+  @ManyToOne(() => RaceSeasonEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'season_id' })
+  season: RaceSeasonEntity;
+}

--- a/server/src/features/statistics/race-events/race-event.module.ts
+++ b/server/src/features/statistics/race-events/race-event.module.ts
@@ -5,9 +5,13 @@ import { RaceEventController } from 'features/statistics/race-events/race-event.
 import { RaceEventEntity } from 'features/statistics/race-events/race-event.entity';
 import { RaceEventRepository } from 'features/statistics/race-events/race-event.repository';
 import { RaceEventService } from 'features/statistics/race-events/race-event.service';
+import { RaceClassificationModule } from 'features/statistics/race-classifications/race-classification.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RaceEventEntity])],
+  imports: [
+    TypeOrmModule.forFeature([RaceEventEntity]),
+    RaceClassificationModule,
+  ],
   controllers: [RaceEventController],
   providers: [RaceEventService, RaceEventRepository],
   exports: [RaceEventService],

--- a/server/src/features/statistics/race-events/race-event.module.ts
+++ b/server/src/features/statistics/race-events/race-event.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RaceEventController } from 'features/statistics/race-events/race-event.controller';
+import { RaceEventEntity } from 'features/statistics/race-events/race-event.entity';
+import { RaceEventRepository } from 'features/statistics/race-events/race-event.repository';
+import { RaceEventService } from 'features/statistics/race-events/race-event.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RaceEventEntity])],
+  controllers: [RaceEventController],
+  providers: [RaceEventService, RaceEventRepository],
+  exports: [RaceEventService],
+})
+export class RaceEventModule {}

--- a/server/src/features/statistics/race-events/race-event.repository.ts
+++ b/server/src/features/statistics/race-events/race-event.repository.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { RaceEventEntity } from 'features/statistics/race-events/race-event.entity';
+
+import {
+  RACE_EVENT_MANY_SELECT_BY_SEASON,
+  RACE_EVENT_ONE_SELECT,
+} from 'features/statistics/race-events/constants/race-events.constants';
+
+@Injectable()
+export class RaceEventRepository {
+  constructor(
+    @InjectRepository(RaceEventEntity)
+    private repo: Repository<RaceEventEntity>,
+  ) {}
+
+  async getRaceEventsBySeason(seasonId: number): Promise<RaceEventEntity[]> {
+    return this.repo.find({
+      select: RACE_EVENT_MANY_SELECT_BY_SEASON,
+      where: { season: { id: seasonId } },
+      relations: ['circuit'],
+      order: {
+        eventStage: 'ASC',
+      },
+    });
+  }
+
+  async getRaceEventById(id: number): Promise<RaceEventEntity | null> {
+    return this.repo.findOne({
+      select: RACE_EVENT_ONE_SELECT,
+      where: { id },
+      relations: ['circuit', 'season', 'season.discipline'],
+    });
+  }
+}

--- a/server/src/features/statistics/race-events/race-event.service.ts
+++ b/server/src/features/statistics/race-events/race-event.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+
+import { RaceEventRepository } from 'features/statistics/race-events/race-event.repository';
+import {
+  RaceEventDetailedDto,
+  RaceEventShortDto,
+} from 'features/statistics/race-events/dto';
+
+@Injectable()
+export class RaceEventService {
+  constructor(private repo: RaceEventRepository) {}
+
+  async getRaceEventsBySeason(seasonId: number): Promise<RaceEventShortDto[]> {
+    return plainToInstance(
+      RaceEventShortDto,
+      await this.repo.getRaceEventsBySeason(seasonId),
+    );
+  }
+
+  async getRaceEventById(id: number): Promise<RaceEventDetailedDto> {
+    const raceEvent = await this.repo.getRaceEventById(id);
+    if (!raceEvent)
+      throw new NotFoundException('Such race event does not exist');
+
+    return plainToInstance(RaceEventDetailedDto, raceEvent);
+  }
+}

--- a/server/src/features/statistics/race-events/race-event.service.ts
+++ b/server/src/features/statistics/race-events/race-event.service.ts
@@ -6,10 +6,14 @@ import {
   RaceEventDetailedDto,
   RaceEventShortDto,
 } from 'features/statistics/race-events/dto';
+import { RaceClassificationService } from 'features/statistics/race-classifications/race-classification.service';
 
 @Injectable()
 export class RaceEventService {
-  constructor(private repo: RaceEventRepository) {}
+  constructor(
+    private raceClassificationService: RaceClassificationService,
+    private repo: RaceEventRepository,
+  ) {}
 
   async getRaceEventsBySeason(seasonId: number): Promise<RaceEventShortDto[]> {
     return plainToInstance(
@@ -18,11 +22,17 @@ export class RaceEventService {
     );
   }
 
-  async getRaceEventById(id: number): Promise<RaceEventDetailedDto> {
+  async getRaceEventById(id: number) {
     const raceEvent = await this.repo.getRaceEventById(id);
     if (!raceEvent)
       throw new NotFoundException('Such race event does not exist');
 
-    return plainToInstance(RaceEventDetailedDto, raceEvent);
+    const converted = plainToInstance(RaceEventDetailedDto, raceEvent);
+
+    return {
+      ...converted,
+      classification:
+        await this.raceClassificationService.getClassificationsForRaceEvent(id),
+    };
   }
 }

--- a/server/src/features/statistics/race-seasons/constants/race-season.constants.ts
+++ b/server/src/features/statistics/race-seasons/constants/race-season.constants.ts
@@ -6,4 +6,5 @@ export const RACE_SEASON_MANY_SELECT = {
     name: true,
     logoUrl: true,
   },
+  stages: true,
 };

--- a/server/src/features/statistics/race-seasons/constants/race-season.constants.ts
+++ b/server/src/features/statistics/race-seasons/constants/race-season.constants.ts
@@ -1,0 +1,9 @@
+export const RACE_SEASON_MANY_SELECT = {
+  id: true,
+  seasonYear: true,
+  discipline: {
+    id: true,
+    name: true,
+    logoUrl: true,
+  },
+};

--- a/server/src/features/statistics/race-seasons/dto/index.ts
+++ b/server/src/features/statistics/race-seasons/dto/index.ts
@@ -1,0 +1,2 @@
+export { RaceSeasonDto } from './race-season.dto';
+export { RaceSeasonQueryDto } from './race-season-query.dto';

--- a/server/src/features/statistics/race-seasons/dto/race-season-query.dto.ts
+++ b/server/src/features/statistics/race-seasons/dto/race-season-query.dto.ts
@@ -1,0 +1,6 @@
+export type RaceSeasonQueryDto = {
+  seasonYear?: number;
+  discipline?: {
+    shortCode: string;
+  };
+};

--- a/server/src/features/statistics/race-seasons/dto/race-season.dto.ts
+++ b/server/src/features/statistics/race-seasons/dto/race-season.dto.ts
@@ -1,0 +1,18 @@
+import { Expose, Type } from 'class-transformer';
+
+import { DisciplineDto } from 'features/disciplines/dto';
+
+export class RaceSeasonDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  seasonYear: number;
+
+  @Expose()
+  stages: number;
+
+  @Expose()
+  @Type(() => DisciplineDto)
+  discipline: DisciplineDto;
+}

--- a/server/src/features/statistics/race-seasons/race-season.controller.ts
+++ b/server/src/features/statistics/race-seasons/race-season.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+
+import { RaceSeasonService } from 'features/statistics/race-seasons/race-season.service';
+import { RaceSeasonQuery } from 'features/statistics/race-seasons/types/race-season.query';
+
+@Controller('race-seasons')
+export class RaceSeasonController {
+  constructor(private service: RaceSeasonService) {}
+
+  @Get()
+  async getRaceSeasonsByConditions(@Query() query: RaceSeasonQuery) {
+    return this.service.getRaceSeasonsByConditions(query);
+  }
+
+  @Get(':id')
+  async getRaceSeasonById(@Param('id', ParseIntPipe) id: number) {
+    return this.service.getRaceSeasonById(id);
+  }
+}

--- a/server/src/features/statistics/race-seasons/race-season.entity.ts
+++ b/server/src/features/statistics/race-seasons/race-season.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { DisciplineEntity } from 'features/disciplines/discipline.entity';
+
+@Entity('race_seasons')
+@Index('unique_season_discipline', ['seasonYear', 'discipline'], {
+  unique: true,
+})
+export class RaceSeasonEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'season_year', type: 'int' })
+  seasonYear: number;
+
+  @ManyToOne(() => DisciplineEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'discipline_id' })
+  discipline: DisciplineEntity;
+}

--- a/server/src/features/statistics/race-seasons/race-season.entity.ts
+++ b/server/src/features/statistics/race-seasons/race-season.entity.ts
@@ -20,6 +20,9 @@ export class RaceSeasonEntity {
   @Column({ name: 'season_year', type: 'int' })
   seasonYear: number;
 
+  @Column()
+  stages: number;
+
   @ManyToOne(() => DisciplineEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'discipline_id' })
   discipline: DisciplineEntity;

--- a/server/src/features/statistics/race-seasons/race-season.module.ts
+++ b/server/src/features/statistics/race-seasons/race-season.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { RaceEventModule } from 'features/statistics/race-events/race-event.module';
 import { RaceSeasonController } from 'features/statistics/race-seasons/race-season.controller';
 import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
 import { RaceSeasonRepository } from 'features/statistics/race-seasons/race-season.repository';
 import { RaceSeasonService } from 'features/statistics/race-seasons/race-season.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RaceSeasonEntity])],
+  imports: [TypeOrmModule.forFeature([RaceSeasonEntity]), RaceEventModule],
   controllers: [RaceSeasonController],
   providers: [RaceSeasonService, RaceSeasonRepository],
 })

--- a/server/src/features/statistics/race-seasons/race-season.module.ts
+++ b/server/src/features/statistics/race-seasons/race-season.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RaceSeasonController } from 'features/statistics/race-seasons/race-season.controller';
+import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
+import { RaceSeasonRepository } from 'features/statistics/race-seasons/race-season.repository';
+import { RaceSeasonService } from 'features/statistics/race-seasons/race-season.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RaceSeasonEntity])],
+  controllers: [RaceSeasonController],
+  providers: [RaceSeasonService, RaceSeasonRepository],
+})
+export class RaceSeasonModule {}

--- a/server/src/features/statistics/race-seasons/race-season.repository.ts
+++ b/server/src/features/statistics/race-seasons/race-season.repository.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
+import { RACE_SEASON_MANY_SELECT } from 'features/statistics/race-seasons/constants/race-season.constants';
+import { RaceSeasonQueryDto } from 'features/statistics/race-seasons/dto/race-season-query.dto';
+
+@Injectable()
+export class RaceSeasonRepository {
+  constructor(
+    @InjectRepository(RaceSeasonEntity)
+    private repo: Repository<RaceSeasonEntity>,
+  ) {}
+
+  async getRaceSeasons(
+    conditions: RaceSeasonQueryDto,
+  ): Promise<RaceSeasonEntity[]> {
+    return this.repo.find({
+      select: RACE_SEASON_MANY_SELECT,
+      where: conditions,
+      relations: ['discipline'],
+      order: {
+        seasonYear: 'DESC',
+      },
+    });
+  }
+
+  async getRaceSeasonById(id: number): Promise<RaceSeasonEntity | null> {
+    return this.repo.findOne({
+      where: { id },
+      relations: ['discipline'],
+    });
+  }
+}

--- a/server/src/features/statistics/race-seasons/race-season.repository.ts
+++ b/server/src/features/statistics/race-seasons/race-season.repository.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 
 import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
 import { RACE_SEASON_MANY_SELECT } from 'features/statistics/race-seasons/constants/race-season.constants';
-import { RaceSeasonQueryDto } from 'features/statistics/race-seasons/dto/race-season-query.dto';
+import { RaceSeasonQueryDto } from 'features/statistics/race-seasons/dto';
 
 @Injectable()
 export class RaceSeasonRepository {

--- a/server/src/features/statistics/race-seasons/race-season.service.ts
+++ b/server/src/features/statistics/race-seasons/race-season.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
+import { RaceSeasonRepository } from 'features/statistics/race-seasons/race-season.repository';
+import { RaceSeasonQuery } from 'features/statistics/race-seasons/types/race-season.query';
+import { RaceSeasonQueryDto } from 'features/statistics/race-seasons/dto/race-season-query.dto';
+
+@Injectable()
+export class RaceSeasonService {
+  constructor(private repo: RaceSeasonRepository) {}
+
+  async getRaceSeasonsByConditions(
+    query: RaceSeasonQuery,
+  ): Promise<RaceSeasonEntity[]> {
+    const queryDto: RaceSeasonQueryDto = {
+      discipline: {
+        shortCode: query.discipline,
+      },
+      seasonYear: query.year,
+    };
+
+    return this.repo.getRaceSeasons(queryDto);
+  }
+
+  async getRaceSeasonById(id: number): Promise<RaceSeasonEntity> {
+    const season = await this.repo.getRaceSeasonById(id);
+    if (!season)
+      throw new NotFoundException('Such season is not found in the database');
+
+    return season;
+  }
+}

--- a/server/src/features/statistics/race-seasons/race-season.service.ts
+++ b/server/src/features/statistics/race-seasons/race-season.service.ts
@@ -1,17 +1,24 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
 
-import { RaceSeasonEntity } from 'features/statistics/race-seasons/race-season.entity';
 import { RaceSeasonRepository } from 'features/statistics/race-seasons/race-season.repository';
+import { RaceEventService } from 'features/statistics/race-events/race-event.service';
+import {
+  RaceSeasonDto,
+  RaceSeasonQueryDto,
+} from 'features/statistics/race-seasons/dto';
 import { RaceSeasonQuery } from 'features/statistics/race-seasons/types/race-season.query';
-import { RaceSeasonQueryDto } from 'features/statistics/race-seasons/dto/race-season-query.dto';
 
 @Injectable()
 export class RaceSeasonService {
-  constructor(private repo: RaceSeasonRepository) {}
+  constructor(
+    private raceEventService: RaceEventService,
+    private repo: RaceSeasonRepository,
+  ) {}
 
   async getRaceSeasonsByConditions(
     query: RaceSeasonQuery,
-  ): Promise<RaceSeasonEntity[]> {
+  ): Promise<RaceSeasonDto[]> {
     const queryDto: RaceSeasonQueryDto = {
       discipline: {
         shortCode: query.discipline,
@@ -19,14 +26,19 @@ export class RaceSeasonService {
       seasonYear: query.year,
     };
 
-    return this.repo.getRaceSeasons(queryDto);
+    return plainToInstance(
+      RaceSeasonDto,
+      await this.repo.getRaceSeasons(queryDto),
+    );
   }
 
-  async getRaceSeasonById(id: number): Promise<RaceSeasonEntity> {
+  async getRaceSeasonById(id: number) {
     const season = await this.repo.getRaceSeasonById(id);
     if (!season)
       throw new NotFoundException('Such season is not found in the database');
 
-    return season;
+    const raceEvents = await this.raceEventService.getRaceEventsBySeason(id);
+
+    return { ...season, raceEvents };
   }
 }

--- a/server/src/features/statistics/race-seasons/types/race-season.query.ts
+++ b/server/src/features/statistics/race-seasons/types/race-season.query.ts
@@ -1,0 +1,11 @@
+import { IsNumberString, IsOptional, IsString } from 'class-validator';
+
+export class RaceSeasonQuery {
+  @IsString()
+  @IsOptional()
+  discipline: string;
+
+  @IsNumberString()
+  @IsOptional()
+  year: number;
+}

--- a/server/src/features/statistics/statistics.module.ts
+++ b/server/src/features/statistics/statistics.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { RaceSeasonModule } from 'features/statistics/race-seasons/race-season.module';
+
+@Module({
+  imports: [RaceSeasonModule],
+})
+export class StatisticsModule {}

--- a/server/src/features/statistics/statistics.module.ts
+++ b/server/src/features/statistics/statistics.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 
+import { RaceEventModule } from 'features/statistics/race-events/race-event.module';
 import { RaceSeasonModule } from 'features/statistics/race-seasons/race-season.module';
 
 @Module({
-  imports: [RaceSeasonModule],
+  imports: [RaceEventModule, RaceSeasonModule],
 })
 export class StatisticsModule {}

--- a/server/src/features/statistics/statistics.module.ts
+++ b/server/src/features/statistics/statistics.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 
+import { RaceEntryModule } from 'features/statistics/race-entries/race-entry.module';
 import { RaceEventModule } from 'features/statistics/race-events/race-event.module';
 import { RaceSeasonModule } from 'features/statistics/race-seasons/race-season.module';
 
 @Module({
-  imports: [RaceEventModule, RaceSeasonModule],
+  imports: [RaceEntryModule, RaceEventModule, RaceSeasonModule],
 })
 export class StatisticsModule {}


### PR DESCRIPTION
## Key changes

### Backend

- **Circuit** entity
- Basic display of the **Disciplines** (only GET routes with pagination)
- **Statistics** module
  - **Race seasons** sub-module (with GET routes only)
  - **Race events** sub-module (with GET routes only)

### Frontend
- Display of the **Statistics** UI scope
  - UI for the **Race Seasons** page
  - UI for the **detailed Race Season** page
  - UI for the **detailed Race Event** page
- Translations for the Statistics scope